### PR TITLE
Fix trouble(-)shooting link and some typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Our Enviro range of boards offer a wide array of environmental sensing and data logging functionality. They are designed to be setup in location for months at a time and take regular measurements.
 
 - [Getting started guide](documentation/getting-started.md)
-- [Troubleshooting your Enviro board](documentation/troubleshooting.md)
+- [Troubleshooting your Enviro board](documentation/trouble-shooting.md)
 - [Upgrading firmware](documentation/upgrading-firmware.md)
 
 ## About Enviro

--- a/documentation/developer-guide.md
+++ b/documentation/developer-guide.md
@@ -5,7 +5,7 @@
 
 ### Boot up process
 
-The Enviro boot up process is relatively complex as we need to ensure that things like the real time clock are synchronised and our wireless connection is functional before we attemp to take any readings.
+The Enviro boot up process is relatively complex as we need to ensure that things like the real time clock are synchronised and our wireless connection is functional before we attempt to take any readings.
 
 ```mermaid
   graph TD;
@@ -32,7 +32,7 @@ The Enviro boot up process is relatively complex as we need to ensure that thing
     warning3[Turn on warning LED and sleep]
 
     wake-->button_held
-    
+
     button_held-->|No|is_provisioned
     button_held-->|Yes|provision
 
@@ -41,7 +41,7 @@ The Enviro boot up process is relatively complex as we need to ensure that thing
 
     check_rtc-->|Yes|check_disk_space
     check_rtc-->|No|connect_to_wifi_for_rtc
-    
+
     connect_to_wifi_for_rtc-->|Yes|set_rtc_from_ntp-->check_disk_space
     connect_to_wifi_for_rtc-->|No|warning1
 
@@ -49,7 +49,7 @@ The Enviro boot up process is relatively complex as we need to ensure that thing
     check_disk_space-->|Low|warning2
 
     take_reading-->save_reading-->have_destination
-    
+
     have_destination-->|Yes|cache_for_upload-->need_uploading
 
     need_uploading-->|Yes|connect_to_wifi_for_upload

--- a/documentation/getting-started.md
+++ b/documentation/getting-started.md
@@ -31,11 +31,11 @@ It's a good idea to familiarise yourself with where the buttons and indicators a
 7. Battery connector: compatible with many battery holders and cells
 8. USB connector: for accessing readings files and logs from your computer
 
---- 
+---
 
 ## Provisioning your board
 
-When you recieve your Enviro board it will come preloaded with our software but will not be configured yet. You need to go through the provisioning process to tell it how to connect to your wireless network, when to take readings, and optionally where to upload them.
+When you receive your Enviro board it will come preloaded with our software but will not be configured yet. You need to go through the provisioning process to tell it how to connect to your wireless network, when to take readings, and optionally where to upload them.
 
 Follow these instructions to get your Enviro board configured and running:
 
@@ -69,7 +69,7 @@ A list of nearby wireless networks will be shown.
 
 > Your network not showing? Click **Try scanning again** to refresh the list or move closer to your network router.
 
-Select your network and enter your wireless password. 
+Select your network and enter your wireless password.
 
 If, in the future, your board cannot see the wireless network when it needs to set its clock or upload data then it will blink the **WARN** LED to indicate that there is a problem.
 


### PR DESCRIPTION
Link to troubleshooting doc from README was broken (could alternatively rename the target file).
Tidied some tiny typos in the other docs.

Signed-off-by: Andy Piper <andypiper@users.noreply.github.com>