### PR TITLE
Switch to retained publication for MQTT target

### DIFF
--- a/enviro/destinations/mqtt.py
+++ b/enviro/destinations/mqtt.py
@@ -17,7 +17,7 @@ def upload_readings():
 
   mqtt_client = MQTTClient(nickname, server, user=username, password=password, keepalive=60)
   mqtt_client.connect()
-  
+
   for cache_file in os.ilistdir("uploads"):
     cache_file = cache_file[0]
     try:
@@ -31,9 +31,13 @@ def upload_readings():
         }
         for key, value in data.items():
           payload[key] = value
-        
+
         topic = f"enviro/{nickname}"
-        mqtt_client.publish(topic, ujson.dumps(payload))
+        # by default the MQTT messages will be published with the retain flag
+        # set, so that if a consumer is not subscribed, the most recent set
+        # of readings can still be read by another subscriber later. Change
+        # retain to False (or drop from the method call) below to change this
+        mqtt_client.publish(topic, ujson.dumps(payload), retain=True)
 
         logging.info(f"  - uploaded {cache_file}")
         os.remove(f"uploads/{cache_file}")


### PR DESCRIPTION
Propose changing the MQTT publication to retained by default, this makes it easier to see the last reading published from an Enviro sensor if the viewer / consumer / subscriber joins later. There is already a timestamp in the publication message so should be no risk of being confused at whether that reflects the current, or past, status of the Enviro. Added comments to indicate how to switch this back to False if preferred.

As an aside, I'm now comparing the format of these messages to those published by the MQTT sample shipped with the classic Enviro+ HAT, and will probably send a PR for the latter to get the data formats more aligned if possible.

Signed-off-by: Andy Piper <andypiper@users.noreply.github.com>