### PR TITLE
Switch phew submodule URL to HTTPS.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "phew"]
 	path = phew
-	url = git@github.com:pimoroni/phew.git
+	url = https://github.com/pimoroni/phew


### PR DESCRIPTION
The phew submodule - `git@github.com:pimoroni/phew.git` - URL requires locally configured SSH auth and thus would fail for most users with a public key auth error.

Fix it to HTTPS so it works for everyone!