### PR TITLE
Fix warn_led references

### DIFF
--- a/main.py
+++ b/main.py
@@ -52,7 +52,7 @@ if not enviro.clock_set():
     # if we failed to synchronise the clock then turn on the warning
     # led and go back to sleep for another cycle
     logging.error("! failed to synchronise clock")
-    warn_led(WARN_LED_BLINK)
+    enviro.board.warn_led(enviro.WARN_LED_BLINK)
     enviro.sleep(config.reading_frequency)
 
 
@@ -61,7 +61,7 @@ if enviro.low_disk_space():
   # means that cached results are not getting uploaded and cleared so
   # warn the user and go back to sleep
   logging.error("! low disk space")
-  warn_led(WARN_LED_BLINK)
+  enviro.board.warn_led(enviro.WARN_LED_BLINK)
   enviro.sleep(config.reading_frequency)
 
 filesystem_stats = os.statvfs(".")


### PR DESCRIPTION
The reference to `warn_led` in `main.py` needs qualification, as do the references to the `WARN_LED_` constants. Without these, `main.py` crashes on error leaving the board active (and potentially draining any attached battery).