### PR TITLE
Support SDC41 QTStemma board via detecting it via i2c address.

### DIFF
--- a/enviro/__init__.py
+++ b/enviro/__init__.py
@@ -117,12 +117,19 @@ def save_reading(readings):
   with open(readings_filename, "a") as f:
     if new_file:
       # new readings file so write out column headings first
-      f.write("time," + ",".join(sensors()) + "\r\n")
+      if qtstemma:
+        f.write("time," + ",".join(sensors() + qtsensors()) + "\r\n")
+      else: 
+        f.write("time," + ",".join(sensors()) + "\r\n")
 
     # write sensor data
     row = [helpers.datetime_string()]
-    for key in sensors():
-      row.append(str(readings[key]))
+    if qtstemma is not None:
+      print(sensors() + qtsensors(), readings)
+      print(row)
+      row.extend(str(readings[key]) for key in (sensors() + qtsensors()))
+    else:
+      row.extend(str(readings[key]) for key in sensors())
     f.write(",".join(row) + "\r\n")
 
 
@@ -145,6 +152,10 @@ if model == "weather":
   from enviro.boards.weather import sensors, get_sensor_readings
 if model == "urban":
   from enviro.boards.urban import sensors, get_sensor_readings
+
+qtstemma = board.qtstemma()
+if qtstemma == "scd41":
+  from enviro.boards.scd41 import qtsensors, get_qtsensor_readings
 
 destination = helpers.get_config("destination")
 if destination == "http":

--- a/enviro/__init__.py
+++ b/enviro/__init__.py
@@ -125,8 +125,6 @@ def save_reading(readings):
     # write sensor data
     row = [helpers.datetime_string()]
     if qtstemma is not None:
-      print(sensors() + qtsensors(), readings)
-      print(row)
       row.extend(str(readings[key]) for key in (sensors() + qtsensors()))
     else:
       row.extend(str(readings[key]) for key in sensors())

--- a/enviro/board.py
+++ b/enviro/board.py
@@ -124,5 +124,16 @@ def model():
   return result
 
 
+def qtstemma():
+  # determine which type of board is connected
+  i2c_devices = i2c.scan()
+
+  result = None
+  if 98 in i2c_devices: # 98 = sdc41 0x62
+    result = "scd41"
+    logging.info("Detected scd41 on i2c")
+
+  return result
+
 def reset():
   machine.reset()

--- a/enviro/boards/scd41.py
+++ b/enviro/boards/scd41.py
@@ -2,6 +2,10 @@ from phew import logging as logging
 import time
 import breakout_scd41
 
+# CO2 Sensor
+# https://shop.pimoroni.com/products/scd41-co2-sensor-breakout
+# https://github.com/pimoroni/pimoroni-pico/tree/main/micropython/modules/breakout_scd41
+
 from enviro.board import i2c
 
 breakout_scd41.init(i2c)
@@ -16,13 +20,8 @@ def qtsensors():
 def get_qtsensor_readings():
     breakout_scd41.start()
     while breakout_scd41.ready() is False:
-        logging.info("CO2 sensor not ready, sleeping")
+        logging.info("CO2 sensor not ready, sleeping 5s")
         time.sleep(5)
     scd41_co2, scd41_temperature, scd41_relative_humidity = breakout_scd41.measure()
     breakout_scd41.stop()
-    measurements = {
-        "scd41_co2": scd41_co2,
-        "scd41_temperature": scd41_temperature,
-        "scd41_humidity": scd41_relative_humidity,
-    }
-    return measurements
+    return {"scd41_co2": scd41_co2, "scd41_temperature": scd41_temperature, "scd41_humidity": scd41_relative_humidity}

--- a/enviro/boards/scd41.py
+++ b/enviro/boards/scd41.py
@@ -1,0 +1,28 @@
+from phew import logging as logging
+import time
+import breakout_scd41
+
+from enviro.board import i2c
+
+breakout_scd41.init(i2c)
+
+def qtsensors():
+    return [
+        "scd41_co2",
+        "scd41_temperature",
+        "scd41_humidity"
+    ]
+
+def get_qtsensor_readings():
+    breakout_scd41.start()
+    while breakout_scd41.ready() is False:
+        logging.info("CO2 sensor not ready, sleeping")
+        time.sleep(5)
+    scd41_co2, scd41_temperature, scd41_relative_humidity = breakout_scd41.measure()
+    breakout_scd41.stop()
+    measurements = {
+        "scd41_co2": scd41_co2,
+        "scd41_temperature": scd41_temperature,
+        "scd41_humidity": scd41_relative_humidity,
+    }
+    return measurements

--- a/enviro/config_template.py
+++ b/enviro/config_template.py
@@ -18,7 +18,7 @@ log_count = 20
 # how often to wake up and take a reading (in minutes)
 reading_frequency = 15
 
-# where to upload to ("web_hook", "mqtt", "adafruitio")
+# where to upload to ("web_hook", "mqtt", "adafruit_io")
 destination = None
 
 # how often to upload data (number of cached readings)

--- a/main.py
+++ b/main.py
@@ -23,7 +23,6 @@ import enviro
 from enviro import logging
 import time, os, urequests
 
-
 # initialise 
 enviro.startup()
 
@@ -69,7 +68,10 @@ logging.debug(f"> {filesystem_stats[3]} blocks free out of {filesystem_stats[2]}
 
 
 # take a reading from the sensors
-reading = enviro.get_sensor_readings()
+if enviro.board.qtstemma:
+  reading = dict(enviro.get_sensor_readings(),**enviro.get_qtsensor_readings()) # Merge dicts
+else:
+  reading = enviro.get_sensor_readings()
 
 
 # save the reading into the local reading files (look in "/readings")

--- a/main.py
+++ b/main.py
@@ -23,6 +23,7 @@ import enviro
 from enviro import logging
 import time, os, urequests
 
+
 # initialise 
 enviro.startup()
 


### PR DESCRIPTION
This adds functionality to detect a single QT Stemma board. Right now the only supported module is the SCD41, but I think that this template should work for people to add boards as they need. 

If no qtstemma boards are detected then nothing changes.

