### PR TITLE
CI: Build filesystem .uf2 with dir2uf2.

### DIFF
--- a/.github/workflows/release-zip.yml
+++ b/.github/workflows/release-zip.yml
@@ -25,6 +25,7 @@ jobs:
     - uses: actions/checkout@v2
       with:
         repository: gadgetoid/dir2uf2
+        ref: v0.0.1
         path: dir2uf2
 
     - name: Prepare repository

--- a/.github/workflows/release-zip.yml
+++ b/.github/workflows/release-zip.yml
@@ -33,7 +33,7 @@ jobs:
       run: |
         python3 -m pip install littlefs-python
         wget ${{env.FIRMWARE_URL}}/${{env.FIRMWARE_NAME}}.uf2
-        ./dir2uf2/dir2uf2 --append-to ${{env.FIRMWARE_NAME}}.uf2 --manifest dir2uf2/enviro.txt --filename ${{env.RELEASE_FILE}}.uf2 enviro/
+        ./dir2uf2/dir2uf2 --append-to ${{env.FIRMWARE_NAME}}.uf2 --manifest enviro/uf2-manifest.txt --filename ${{env.RELEASE_FILE}}.uf2 enviro/
         rm -rf enviro/.git*
         rm -rf enviro/phew/.git*
 

--- a/.github/workflows/release-zip.yml
+++ b/.github/workflows/release-zip.yml
@@ -13,6 +13,8 @@ jobs:
 
     env:
       RELEASE_FILE: enviro-${{github.event.release.tag_name || github.sha}}
+      FIRMWARE_NAME: pimoroni-picow_enviro-1.19.7-micropython
+      FIRMWARE_URL: https://github.com/pimoroni/pimoroni-pico/releases/download/1.19.7/
 
     steps:
     - uses: actions/checkout@v2
@@ -29,7 +31,8 @@ jobs:
       shell: bash
       run: |
         python3 -m pip install littlefs-python
-        ./dir2uf2/dir2uf2 --manifest dir2uf2/enviro.txt --filename ${{env.RELEASE_FILE}}-filesystem-only.uf2 enviro/
+        wget ${{env.FIRMWARE_URL}}/${{env.FIRMWARE_NAME}}.uf2
+        ./dir2uf2/dir2uf2 --append-to ${{env.FIRMWARE_NAME}}.uf2 --manifest dir2uf2/enviro.txt --filename ${{env.RELEASE_FILE}}.uf2 enviro/
         rm -rf enviro/.git*
         rm -rf enviro/phew/.git*
 
@@ -44,13 +47,19 @@ jobs:
         name: ${{env.RELEASE_FILE}}
         path: enviro/
 
-    - name: Store .zip as artifact
+    - name: Store filesystem .uf2 as artifact
       uses: actions/upload-artifact@v2
       with:
         name: ${{env.RELEASE_FILE}}-filesystem-only
-        path: ${{env.RELEASE_FILE}}-filesystem-only.uf2
+        path: ${{env.RELEASE_FILE}}.uf2
 
-    - name: Upload .zip
+    - name: Store full .uf2 as artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: ${{env.FIRMWARE_NAME}}-${{env.RELEASE_FILE}}.uf2
+        path: ${{env.FIRMWARE_NAME}}-${{env.RELEASE_FILE}}.uf2
+
+    - name: Upload source .zip
       if: github.event_name == 'release'
       uses: actions/upload-release-asset@v1
       env:
@@ -61,13 +70,24 @@ jobs:
         asset_name: ${{env.RELEASE_FILE}}.zip
         asset_content_type: application/octet-stream
 
-    - name: Upload .uf2
+    - name: Upload filesystem .uf2
       if: github.event_name == 'release'
       uses: actions/upload-release-asset@v1
       env:
         GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
       with:
-        asset_path: ${{env.RELEASE_FILE}}-filesystem-only.uf2
+        asset_path: ${{env.RELEASE_FILE}}.uf2
         upload_url: ${{github.event.release.upload_url}}
         asset_name: ${{env.RELEASE_FILE}}-filesystem-only.uf2
+        asset_content_type: application/octet-stream
+
+    - name: Upload full firmware .uf2
+      if: github.event_name == 'release'
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+      with:
+        asset_path: ${{env.FIRMWARE_NAME}}-${{env.RELEASE_FILE}}.uf2
+        upload_url: ${{github.event.release.upload_url}}
+        asset_name: ${{env.FIRMWARE_NAME}}-${{env.RELEASE_FILE}}.uf2
         asset_content_type: application/octet-stream

--- a/.github/workflows/release-zip.yml
+++ b/.github/workflows/release-zip.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-20.04
 
     env:
-      RELEASE_FILE: enviro
+      RELEASE_FILE: enviro-${{github.event.release.tag_name || github.sha}}
 
     steps:
     - uses: actions/checkout@v2
@@ -20,9 +20,16 @@ jobs:
         path: enviro
         submodules: true
 
+    - uses: actions/checkout@v2
+      with:
+        repository: gadgetoid/dir2uf2
+        path: dir2uf2
+
     - name: Prepare repository
       shell: bash
       run: |
+        python3 -m pip install littlefs-python
+        ./dir2uf2/dir2uf2 --manifest dir2uf2/enviro.txt --filename ${{env.RELEASE_FILE}}-filesystem-only.uf2 enviro/
         rm -rf enviro/.git*
         rm -rf enviro/phew/.git*
 
@@ -37,6 +44,12 @@ jobs:
         name: ${{env.RELEASE_FILE}}
         path: enviro/
 
+    - name: Store .zip as artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: ${{env.RELEASE_FILE}}-filesystem-only
+        path: ${{env.RELEASE_FILE}}-filesystem-only.uf2
+
     - name: Upload .zip
       if: github.event_name == 'release'
       uses: actions/upload-release-asset@v1
@@ -46,4 +59,15 @@ jobs:
         asset_path: ${{env.RELEASE_FILE}}.zip
         upload_url: ${{github.event.release.upload_url}}
         asset_name: ${{env.RELEASE_FILE}}.zip
+        asset_content_type: application/octet-stream
+
+    - name: Upload .uf2
+      if: github.event_name == 'release'
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+      with:
+        asset_path: ${{env.RELEASE_FILE}}-filesystem-only.uf2
+        upload_url: ${{github.event.release.upload_url}}
+        asset_name: ${{env.RELEASE_FILE}}-filesystem-only.uf2
         asset_content_type: application/octet-stream

--- a/uf2-manifest.txt
+++ b/uf2-manifest.txt
@@ -1,0 +1,8 @@
+main.py
+enviro/*.py
+enviro/boards/*.py
+enviro/destinations/*.py
+enviro/html/*.html
+enviro/html/images/*
+phew/__init__.py
+phew/phew/*.py


### PR DESCRIPTION
I have created a test release with instructions for using the filesystem .uf2 here - https://github.com/pimoroni/enviro/releases/tag/v0.0.6-test

I've raised this as a *draft* PR because currently it just pulls my dir2uf2 GitHub repository and runs the utility from there. This all needs tidying up before it's ready for primetime.

### TODO:

* [ ] - Publish dir2uf2 on pypi - though it needs a better name first!
* [x] - Move the diru2f manifest file (enviro.txt) into *this* repository
* [x] - Update this PR accordingly
* [x] - Test!
* [x] - Stretch Goal: Figure out how to join the two .uf2 files together into a final, one-shot firmware.