### PR TITLE
Fixes API usage and possible division by 0 for wind speed

### DIFF
--- a/enviro/boards/weather.py
+++ b/enviro/boards/weather.py
@@ -53,7 +53,7 @@ def wind_speed(sample_time_ms=1000):
   ticks = []
   
   start = time.ticks_ms()
-  while time.ticks_ms() - start <= sample_time_ms:
+  while time.ticks_diff(time.ticks_ms(), start) <= sample_time_ms:
     now = wind_speed_pin.value()
     if now != state: # sensor output changed
       # record the time of the change and update the state
@@ -65,7 +65,7 @@ def wind_speed(sample_time_ms=1000):
     return 0
 
   # calculate the average tick between transitions in ms
-  average_tick_ms = (ticks[-1] - ticks[0]) / (len(ticks) - 1)
+  average_tick_ms = (time.ticks_diff(ticks[-1], ticks[0])) / (len(ticks) - 1)
 
   if average_tick_ms == 0:
     return 0

--- a/enviro/boards/weather.py
+++ b/enviro/boards/weather.py
@@ -67,6 +67,8 @@ def wind_speed(sample_time_ms=1000):
   # calculate the average tick between transitions in ms
   average_tick_ms = (ticks[-1] - ticks[0]) / (len(ticks) - 1)
 
+  if average_tick_ms == 0:
+    return 0
   # work out rotation speed in hz (two ticks per rotation)
   rotation_hz = (1000 / average_tick_ms) / 2
 


### PR DESCRIPTION
- There is no __sub__ method on the time.ticks_xx() API'. So use of the time.ticks_diff(a, b) is the proper usage of the API.
- There is the possibility of having a division by 0 when the ticks are evaluated. I had this at least once.

It might fix some issues reported in: https://github.com/pimoroni/enviro/issues/99. At least will a division by 0 bringing the board into sort of a limbo state which might end freezing (RTC wakeup issue because of ZeroDivisionError)

Tested and running over a week without any issues on a weather board.
