### PR TITLE
Re-Enable the battery monitoring on Enviro! 🥳

### DIFF
--- a/enviro/__init__.py
+++ b/enviro/__init__.py
@@ -108,24 +108,6 @@ config_defaults.add_missing_config_settings()
 # read the state of vbus to know if we were woken up by USB
 vbus_present = Pin("WL_GPIO2", Pin.IN).value()
 
-#BUG Temporarily disabling battery reading, as it seems to cause issues when connected to Thonny
-"""
-# read battery voltage - we have to toggle the wifi chip select
-# pin to take the reading - this is probably not ideal but doesn't
-# seem to cause issues. there is no obvious way to shut down the
-# wifi for a while properly to do this (wlan.disonnect() and
-# wlan.active(False) both seem to mess things up big style..)
-old_state = Pin(WIFI_CS_PIN).value()
-Pin(WIFI_CS_PIN, Pin.OUT, value=True)
-sample_count = 10
-battery_voltage = 0
-for i in range(0, sample_count):
-  battery_voltage += (ADC(29).read_u16() * 3.3 / 65535) * 3
-battery_voltage /= sample_count
-battery_voltage = round(battery_voltage, 3)
-Pin(WIFI_CS_PIN).value(old_state)
-"""
-
 # set up the button, external trigger, and rtc alarm pins
 rtc_alarm_pin = Pin(RTC_ALARM_PIN, Pin.IN, Pin.PULL_DOWN)
 # BUG This should only be set up for Enviro Camera
@@ -358,7 +340,7 @@ def get_sensor_readings():
 
 
   readings = get_board().get_sensor_readings(seconds_since_last)
-  if config.enable_battery_voltage:
+  if hasattr(config, 'enable_battery_voltage') and config.enable_battery_voltage:
     readings["voltage"] = get_battery_voltage()
 
 

--- a/enviro/__init__.py
+++ b/enviro/__init__.py
@@ -2,6 +2,9 @@
 # ===========================================================================
 from enviro.constants import *
 from machine import Pin
+
+from enviro.util_functions import get_battery_voltage, get_cpu_temperature
+
 hold_vsys_en_pin = Pin(HOLD_VSYS_EN_PIN, Pin.OUT, value=True)
 
 # detect board model based on devices on the i2c bus and pin state
@@ -176,7 +179,7 @@ def connect_to_wifi():
   logging.info("  - ip address: ", ip)
   """
   import rp2
-  rp2.country("GB") 
+  rp2.country("GB")
   wlan = network.WLAN(network.STA_IF)
   wlan.active(True)
   wlan.connect(wifi_ssid, wifi_password)
@@ -224,7 +227,7 @@ def low_disk_space():
     return (os.statvfs(".")[3] / os.statvfs(".")[2]) < 0.1   
   return False
 
-# returns True if the rtc clock has been set recently 
+# returns True if the rtc clock has been set recently
 def is_clock_set():
   # is the year on or before 2020?
   if rtc.datetime()[0] <= 2020:
@@ -283,10 +286,10 @@ def sync_clock_from_ntp():
     return False
 
   logging.info("  - rtc synched")
-  
+
   # write out the sync time log
   with open("sync_time.txt", "w") as syncfile:
-    syncfile.write("{0:04d}-{1:02d}-{2:02d}T{3:02d}:{4:02d}:{5:02d}Z".format(*timestamp))  
+    syncfile.write("{0:04d}-{1:02d}-{2:02d}T{3:02d}:{4:02d}:{5:02d}Z".format(*timestamp))
 
   return True
 
@@ -354,8 +357,9 @@ def get_sensor_readings():
     logging.info(f"  - seconds since last reading: {seconds_since_last}")
 
 
-  readings = get_board().get_sensor_readings(seconds_since_last, vbus_present)
-  # readings["voltage"] = 0.0 # battery_voltage #Temporarily removed until issue is fixed
+  readings = get_board().get_sensor_readings(seconds_since_last)
+  readings["voltage"] = get_battery_voltage()
+
 
   # write out the last time log
   with open("last_time.txt", "w") as timefile:
@@ -438,7 +442,7 @@ def upload_readings():
             # remove the sync time file to trigger a resync on next boot
             if helpers.file_exists("sync_time.txt"):
               os.remove("sync_time.txt")
-             
+
             # write out that we want to attempt a reupload
             with open("reattempt_upload.txt", "w") as attemptfile:
               attemptfile.write("")

--- a/enviro/__init__.py
+++ b/enviro/__init__.py
@@ -3,7 +3,7 @@
 from enviro.constants import *
 from machine import Pin
 
-from enviro.util_functions import get_battery_voltage, get_cpu_temperature
+from enviro.util_functions import get_battery_voltage
 
 hold_vsys_en_pin = Pin(HOLD_VSYS_EN_PIN, Pin.OUT, value=True)
 
@@ -358,7 +358,8 @@ def get_sensor_readings():
 
 
   readings = get_board().get_sensor_readings(seconds_since_last)
-  readings["voltage"] = get_battery_voltage()
+  if config.enable_battery_voltage:
+    readings["voltage"] = get_battery_voltage()
 
 
   # write out the last time log

--- a/enviro/config_template.py
+++ b/enviro/config_template.py
@@ -18,6 +18,9 @@ reading_frequency = 15
 # how often to trigger a resync of the onboard RTC (in hours)
 resync_frequency = 168
 
+# Feature toggles
+enable_battery_voltage = False
+
 # where to upload to ("http", "mqtt", "adafruit_io", "influxdb")
 destination = None
 

--- a/enviro/config_template.py
+++ b/enviro/config_template.py
@@ -18,14 +18,14 @@ reading_frequency = 15
 # how often to trigger a resync of the onboard RTC (in hours)
 resync_frequency = 168
 
-# Feature toggles
-enable_battery_voltage = False
-
 # where to upload to ("http", "mqtt", "adafruit_io", "influxdb")
 destination = None
 
 # how often to upload data (number of cached readings)
 upload_frequency = 5
+
+# Feature toggles
+enable_battery_voltage = False
 
 # web hook settings
 custom_http_url = None

--- a/enviro/util_functions.py
+++ b/enviro/util_functions.py
@@ -30,7 +30,3 @@ def get_battery_voltage():
 def _read_vsys_voltage():
   adc_Vsys = machine.ADC(3)
   return adc_Vsys.read_u16() * 3.0 * ADC_VOLT_CONVERSATION
-
-
-def stop_wifi():
-  pass

--- a/enviro/util_functions.py
+++ b/enviro/util_functions.py
@@ -1,7 +1,5 @@
 import machine
 
-# cpu temperature declaration
-CPU_TEMP = machine.ADC(machine.ADC.CORE_TEMP)
 ADC_VOLT_CONVERSATION = 3.3 / 65535
 
 

--- a/enviro/util_functions.py
+++ b/enviro/util_functions.py
@@ -1,0 +1,41 @@
+import machine
+
+# cpu temperature declaration
+CPU_TEMP = machine.ADC(machine.ADC.CORE_TEMP)
+ADC_VOLT_CONVERSATION = 3.3 / 65535
+
+
+def set_pad(gpio, value):
+  machine.mem32[0x4001c000 | (4 + (4 * gpio))] = value
+
+
+def get_pad(gpio):
+  return machine.mem32[0x4001c000 | (4 + (4 * gpio))]
+
+
+def get_battery_voltage():
+  old_pad = get_pad(29)
+  set_pad(29, 128)  # no pulls, no output, no input
+
+  sample_count = 10
+  battery_voltage = 0
+  for i in range(0, sample_count):
+    battery_voltage += _read_vsys_voltage()
+  battery_voltage /= sample_count
+  battery_voltage = round(battery_voltage, 3)
+  set_pad(29, old_pad)
+  return battery_voltage
+
+
+def _read_vsys_voltage():
+  adc_Vsys = machine.ADC(3)
+  return adc_Vsys.read_u16() * 3.0 * ADC_VOLT_CONVERSATION
+
+
+def stop_wifi():
+  pass
+
+
+def get_cpu_temperature():
+  reading = CPU_TEMP.read_u16() * ADC_VOLT_CONVERSATION
+  return 27 - (reading - 0.706) / 0.001721

--- a/enviro/util_functions.py
+++ b/enviro/util_functions.py
@@ -34,8 +34,3 @@ def _read_vsys_voltage():
 
 def stop_wifi():
   pass
-
-
-def get_cpu_temperature():
-  reading = CPU_TEMP.read_u16() * ADC_VOLT_CONVERSATION
-  return 27 - (reading - 0.706) / 0.001721


### PR DESCRIPTION
As mentioned in the release note of v0.0.9 the battery voltage monitoring was disabled due to issues with the stability

> One of the big causes of instability of past versions came from the introduction of battery monitoring. The pin to do this is shared with the Pico W's WiFi chip, and it seems there is no 100% safe way to read this without causing connection or other communication issues. Unfortunately the only way to get around this, for now, was to disable the battery monitoring on Enviro 😢

This pull request will solve this after I tested it as well as possible to be more or less 100% sure that the issue is gone. 

**Credit Note:** The solution does (unfortunately) not origin in my own knowledge but was more or less inspired and then a partial C&P action from the following source(s) and super great work of [Daniel Peron](https://github.com/danjperron)
* Forum/Blog: https://forums.raspberrypi.com/viewtopic.php?t=339994
* SourceCode: https://github.com/danjperron/PicoWSolar
All credit to him as he did the _hard work_ or at least found a way with fiddling with the low-level documentation and configuration for the PicoW.

The current solution was tested on my Enviro devices. Below is the list of when the patch was applied ie. since when the patch runs on each device(s). All the devices were using the `pimoroni-picow_enviro-v1.19.10-micropython-v0.0.9.uf2` _OS_ as the base.
* 02.01.2023	1x Weather
* 15.01.2023	1x Grow
* 20.01.2023	1x Indoor (one of four)
* 23.01.2023	3x Indoor (rest of them)
* 23.01.2023	1x Urban
Since I applied the patch to these devices on the given dates I never had any instability issues! 🤩

As this feature created a lot of issues in the past I added a _feature toggle_ to the config so that the voltage monitoring can simply be deactivated in case one experience stability issues again with the feature enabled.

**Important:** In the config_template.py is the feature DISABLED by default!


