### PR TITLE
Allow to enter connection details manually

### DIFF
--- a/enviro/__init__.py
+++ b/enviro/__init__.py
@@ -180,6 +180,9 @@ def connect_to_wifi():
   wlan = network.WLAN(network.STA_IF)
   wlan.active(True)
   wlan.connect(wifi_ssid, wifi_password)
+  if config.wifi_ifconfig is not None:
+    logging.info(f"> using manual ip config {config.wifi_ifconfig}")
+    wlan.ifconfig(config.wifi_ifconfig)
 
   start = time.ticks_ms()
   while time.ticks_diff(time.ticks_ms(), start) < 30000:

--- a/enviro/config_template.py
+++ b/enviro/config_template.py
@@ -11,6 +11,7 @@ nickname = None
 # network access details
 wifi_ssid = None
 wifi_password = None
+wifi_ifconfig = None
 
 # how often to wake up and take a reading (in minutes)
 reading_frequency = 15

--- a/enviro/html/header.html
+++ b/enviro/html/header.html
@@ -100,6 +100,12 @@
 
       #done pre {max-height: 20rem; overflow: scroll; background-color: var(--black); border-radius: var(--input-radius); color: white; padding: 1rem;}
 
+      details {user-select: none;}
+      details>summary span.icon {transition: all 0.5s; margin-left: auto;}
+      details[open] summary span.icon { transform: rotate(90deg); }
+      summary {display: flex; cursor: pointer; }
+      summary::-webkit-details-marker {display: none;}
+
       /* adjustments for viewing on phone rather than tablet or computer */
       @media (max-width: 680px) {
         #intro {grid-template-columns: 1fr;}

--- a/enviro/html/provision-step-2-wifi.html
+++ b/enviro/html/provision-step-2-wifi.html
@@ -28,6 +28,32 @@
     <fieldset>
       <input id="wifi_password" name="wifi_password" type="text" value="{{config.wifi_password}}" placeholder="e.g. Cats4lyfe&lt;3!" autocapitalize="none" autocorrect="off" autocomplete="off" spellcheck="false" />
     </fieldset>
+
+    <details>
+      <summary><h2>Advanced configuration</h2>
+        <span class="icon">➔</span>
+      </summary>
+      <p>
+        <aside>Only fill in the following fields if you know what you're doing. Leaving them empty works best in most cases, and they are generally only required if your Wifi network does not have a DHCP service running.</aside>
+        <aside>MAC address: {{mac_address}}</aside>
+        <h2>IPv4 address:</h2>
+        <fieldset>
+          <input id="ipv4_address" name="ipv4_address" type="text" value="{{config.wifi_ifconfig[0]}}" placeholder="e.g. 192.168.0.42" autocapitalize="none" autocorrect="off" autocomplete="off" spellcheck="false" />
+        </fieldset>
+        <h2>Netmask:</h2>
+        <fieldset>
+          <input id="ipv4_netmask" name="ipv4_netmask" type="text" value="{{config.wifi_ifconfig[1]}}" placeholder="e.g. 255.255.255.0" autocapitalize="none" autocorrect="off" autocomplete="off" spellcheck="false" />
+        </fieldset>
+        <h2>Gateway:</h2>
+        <fieldset>
+          <input id="ipv4_gateway" name="ipv4_gateway" type="text" value="{{config.wifi_ifconfig[2]}}" placeholder="e.g. 255.255.255.1" autocapitalize="none" autocorrect="off" autocomplete="off" spellcheck="false" />
+        </fieldset>
+        <h2>DNS server:</h2>
+        <fieldset>
+          <input id="dns_server" name="dns_server" type="text" value="{{config.wifi_ifconfig[3]}}" placeholder="e.g. 8.8.8.8" autocapitalize="none" autocorrect="off" autocomplete="off" spellcheck="false" />
+        </fieldset>
+      </p>
+    </details>
   </form>
 
   <nav>

--- a/install-on-device-fs
+++ b/install-on-device-fs
@@ -34,8 +34,8 @@ function create_directory {
 function copy {
   for file in $1
   do
-    echo -n "> copying file $file"
-    mpremote connect ${DEVICE} cp $file $2 > /dev/null
+    echo "> copying file $file"
+    mpremote connect ${DEVICE} cp $file $2$(basename $file)
     if [ $? -eq 0 ] ; then
       echo " .. done!"
     else


### PR DESCRIPTION
This PR essentially does two things:
- show the MAC address of the WIFI interface in the config page, in case the user needs to provide the mac address in their router (MacAuth or the likes),
- allow to set IPv4, Netmask, Gateway and DNS manually. If not provided, the existing procedure (i.e. DHCP) is used.

Also the install script causes EISDIR errors for me (probable upstream issue: https://github.com/micropython/micropython/issues/9746)

I'd really like if the enviro was able to communicate via IPv6 only (then I wouldn't be having those issues), but it seems like that's not even supported by Micropython (https://github.com/micropython/micropython/issues/3683) which is a shame in 2023.

Edit: Tested on Enviro Indoor Pico W. It's odd though, usually the wifi connection works for a few minutes (syncing the clock and uploading data) and then goes into `wlan.state() == 1`. Connecting the USB cable makes it instantly work again... 