### PR TITLE
Home Assistant (HASS) Discovery via MQTT

### DIFF
--- a/enviro/__init__.py
+++ b/enviro/__init__.py
@@ -466,6 +466,20 @@ def upload_readings():
 
   return True
 
+# HASS Discovery
+def hass_discovery():
+  destination = config.destination
+  try:
+    exec(f"import enviro.destinations.{destination}")
+    destination_module = sys.modules[f"enviro.destinations.{destination}"]
+    destination_module.hass_discovery(model)
+    config.hass_discovery_triggered = True
+  except ImportError:
+    logging.error(f"! cannot find destination {destination}")
+    return False
+  except:
+      logging.error(f"Unknown error in setting HASS Discovery")
+
 def startup():
   import sys
 

--- a/enviro/config_template.py
+++ b/enviro/config_template.py
@@ -36,7 +36,7 @@ mqtt_broker_password = None
 # mqtt broker if using local SSL
 mqtt_broker_ca_file = None
 # Home Assistant Discovery setting
-hass_discovery = False
+hass_discovery = False # This could arguably be set to a text field for better customisability 
 
 # adafruit ui settings
 adafruit_io_username = None

--- a/enviro/config_template.py
+++ b/enviro/config_template.py
@@ -35,6 +35,8 @@ mqtt_broker_username = None
 mqtt_broker_password = None
 # mqtt broker if using local SSL
 mqtt_broker_ca_file = None
+# Home Assistant Discovery setting
+hass_discovery = False
 
 # adafruit ui settings
 adafruit_io_username = None

--- a/enviro/destinations/mqtt.py
+++ b/enviro/destinations/mqtt.py
@@ -58,18 +58,18 @@ def hass_discovery(board_type):
   mqtt_discovery("Enviro Humidity", "humidity", "%", "humidity", board_type) # Humidity
   mqtt_discovery("Enviro Voltage", "voltage", "V", "voltage", board_type) # Voltage
   if (board_type == "weather"):
-    mqtt_discovery("Enviro Luminance", "luminance", "lx", "luminance", board_type) # Luminance
+    mqtt_discovery("Enviro Luminance", "illuminance", "lx", "luminance", board_type) # Luminance
     mqtt_discovery("Enviro Wind Speed", "wind_speed", "m/s", "wind_speed", board_type) # Wind Speed
     mqtt_discovery("Enviro Rain", "precipitation", "mm", "rain", board_type) # Rain
     mqtt_discovery("Enviro Rain Per Second", "precipitation", "mm/s", "rain_per_second", board_type) # Rain Per Second
     #mqtt_discovery("Enviro Wind Direction", "", "°", "wind_direction", board_type) # Wind Direction //HASS doesn't have a device class for direction//
   elif (board_type == "grow"):
-    mqtt_discovery("Enviro Luminance", "luminance", "lx", "luminance", board_type) # Luminance
+    mqtt_discovery("Enviro Luminance", "illuminance", "lx", "luminance", board_type) # Luminance
     mqtt_discovery("Enviro Moisture A", "humidity", "%", "moisture_a", board_type) # Moisture A
     mqtt_discovery("Enviro Moisture B", "humidity", "%", "moisture_b", board_type) # Moisture B
     mqtt_discovery("Enviro Moisture C", "humidity", "%", "moisture_c", board_type) # Moisture C
   elif (board_type == "indoor"):
-    mqtt_discovery("Enviro Luminance", "luminance", "lx", "luminance", board_type) # Luminance
+    mqtt_discovery("Enviro Luminance", "illuminance", "lx", "luminance", board_type) # Luminance
     #mqtt_discovery("Enviro Gas Resistance", "", "Ω", "gas_resistance", board_type) # Gas Resistance //HASS doesn't support resistance as a device class//
     mqtt_discovery("Enviro AQI", "aqi", "&", "aqi", board_type) # AQI
     mqtt_discovery("Enviro Colour Temperature", "temperature", "K", "color_temperature", board_type) # Colo(u)r Temperature

--- a/enviro/destinations/mqtt.py
+++ b/enviro/destinations/mqtt.py
@@ -96,7 +96,7 @@ def mqtt_discovery(name, device_class, unit, value_name, model ):
     },
     "unit_of_meas":unit,
     "dev_cla":device_class,
-    "val_tpl":"{{ value_json." + value_name +" }}",
+    "val_tpl":"{{ value_json.readings." + value_name +" }}",
     "state_cla": "measurement",
     "stat_t":"enviro/" + nickname,
     "name":name,

--- a/enviro/destinations/mqtt.py
+++ b/enviro/destinations/mqtt.py
@@ -100,7 +100,7 @@ def mqtt_discovery(name, device_class, unit, value_name, model ):
     "state_cla": "measurement",
     "stat_t":"enviro/" + nickname,
     "name":name,
-    "uniq_id":"sensor." + nickname + "." + device_class,
+    "uniq_id":"sensor." + nickname + "." + value_name,
   })
   try:
     # attempt to publish reading

--- a/enviro/destinations/mqtt.py
+++ b/enviro/destinations/mqtt.py
@@ -51,3 +51,64 @@ def upload_reading(reading):
     logging.debug(f"  - an exception occurred when uploading.", buf.getvalue())
 
   return UPLOAD_FAILED
+
+def hass_discovery(board_type):
+  mqtt_discovery("Enviro Temperature", "temperature", "°C", "temperature", board_type) # Temperature
+  mqtt_discovery("Enviro Pressure", "pressure", "hPa", "pressure", board_type) # Pressure
+  mqtt_discovery("Enviro Humidity", "humidity", "%", "humidity", board_type) # Humidity
+  mqtt_discovery("Enviro Voltage", "voltage", "V", "voltage", board_type) # Voltage
+  if (board_type == "weather"):
+    mqtt_discovery("Enviro Luminance", "luminance", "lx", "luminance", board_type) # Luminance
+    mqtt_discovery("Enviro Wind Speed", "wind_speed", "m/s", "wind_speed", board_type) # Wind Speed
+    mqtt_discovery("Enviro Rain", "precipitation", "mm", "rain", board_type) # Rain
+    mqtt_discovery("Enviro Rain Per Second", "precipitation", "mm/s", "rain_per_second", board_type) # Rain Per Second
+    #mqtt_discovery("Enviro Wind Direction", "", "°", "wind_direction", board_type) # Wind Direction //HASS doesn't have a device class for direction//
+  elif (board_type == "grow"):
+    mqtt_discovery("Enviro Luminance", "luminance", "lx", "luminance", board_type) # Luminance
+    mqtt_discovery("Enviro Moisture A", "humidity", "%", "moisture_a", board_type) # Moisture A
+    mqtt_discovery("Enviro Moisture B", "humidity", "%", "moisture_b", board_type) # Moisture B
+    mqtt_discovery("Enviro Moisture C", "humidity", "%", "moisture_c", board_type) # Moisture C
+  elif (board_type == "indoor"):
+    mqtt_discovery("Enviro Luminance", "luminance", "lx", "luminance", board_type) # Luminance
+    #mqtt_discovery("Enviro Gas Resistance", "", "Ω", "gas_resistance", board_type) # Gas Resistance //HASS doesn't support resistance as a device class//
+    mqtt_discovery("Enviro AQI", "aqi", "&", "aqi", board_type) # AQI
+    mqtt_discovery("Enviro Colour Temperature", "temperature", "K", "color_temperature", board_type) # Colo(u)r Temperature
+  elif (board_type == "urban"):
+    mqtt_discovery("Enviro Noise", "voltage", "V", "noise", board_type) # Noise
+    mqtt_discovery("Enviro PM1", "pm1", "µg/m³", "pm1", board_type) # PM1
+    mqtt_discovery("Enviro PM2.5", "pm25", "µg/m³", "pm2_5", board_type) # PM2_5
+    mqtt_discovery("Enviro PM10", "pm10", "µg/m³", "pm10", board_type) # PM10
+  
+
+def mqtt_discovery(name, device_class, unit, value_name, model ):
+  server = config.mqtt_broker_address
+  username = config.mqtt_broker_username
+  password = config.mqtt_broker_password
+  nickname = config.nickname
+  from ucollections import OrderedDict
+  obj = OrderedDict({
+    "dev":
+    {
+      "ids":[nickname],
+      "name":nickname,
+      "mdl":"Enviro " + model,
+      "mf":"Pimoroni"
+    },
+    "unit_of_meas":unit,
+    "dev_cla":device_class,
+    "val_tpl":"{{ value_json." + value_name +" }}",
+    "state_cla": "measurement",
+    "stat_t":"enviro/" + nickname,
+    "name":name,
+    "uniq_id":"sensor." + nickname + "." + device_class,
+  })
+  try:
+    # attempt to publish reading
+    mqtt_client = MQTTClient(nickname, server, user=username, password=password, keepalive=60)
+    mqtt_client.connect()
+    mqtt_client.publish(f"homeassistant/sensor/{nickname}/{value_name}/config", ujson.dumps(obj), retain=True)
+    mqtt_client.disconnect()
+    return UPLOAD_SUCCESS
+  except:
+    logging.debug(f"  - an exception occurred when uploading")
+    

--- a/enviro/html/provision-step-4-destination.html
+++ b/enviro/html/provision-step-4-destination.html
@@ -47,6 +47,7 @@
         <fieldset>
           <input type="text" name="mqtt_broker_username" value="{{config.mqtt_broker_username}}" placeholder="Username (e.g. data_junkie)" autocapitalize="none" autocorrect="off" autocomplete="off" spellcheck="false" />
           <input type="text" name="mqtt_broker_password" value="{{config.mqtt_broker_password}}" placeholder="Password (e.g. ih3artd4ta)" autocapitalize="none" autocorrect="off" autocomplete="off" spellcheck="false" />
+          <input type="checkbox" name="hass_discovery" value="{{config.hass_discovery}}" />
         </fieldset>
       </div>
 

--- a/enviro/provisioning.py
+++ b/enviro/provisioning.py
@@ -113,6 +113,7 @@ def provision_step_4_destination(request):
     config.mqtt_broker_address = request.form["mqtt_broker_address"]
     config.mqtt_broker_username = request.form["mqtt_broker_username"]
     config.mqtt_broker_password = request.form["mqtt_broker_password"]
+    config.hass_discovery = request.form["hass_discovery"]
 
     # adafruit io
     config.adafruit_io_username = request.form["adafruit_io_username"]

--- a/main.py
+++ b/main.py
@@ -65,6 +65,11 @@ try:
   filesystem_stats = os.statvfs(".")
   enviro.logging.debug(f"> {filesystem_stats[3]} blocks free out of {filesystem_stats[2]}")
 
+  # Add HASS Discovery command before taking new readings
+  if enviro.config.destination == "mqtt":
+      if enviro.config.hass_discovery:
+        enviro.hass_discovery()
+
   # TODO should the board auto take a reading when the timer has been set, or wait for the time?
   # take a reading from the onboard sensors
   enviro.logging.debug(f"> taking new reading")


### PR DESCRIPTION
I've added Home Assistant discovery to the MQTT destination for all four Enviro boards. It's not absolutely perfect as wind direction and gas resistance aren't detected currently since HASS doesn't have a device class for direction or resistance, but other than that I believe all other entities should work. I've tested this with my Enviro Weather board but since I don't have the other three boards I can't say for sure that those ones will detect. 

This could also be improved for the small group of people who change their HASS MQTT discovery term by replacing the checkbox on the setup page with another text entry field and if the text field is empty the code won't fire the HASS discovery publishes. But I'm burned out enough as it is so a checkbox will have to do.

![image](https://user-images.githubusercontent.com/7023048/222978469-e1fd782f-5b41-47d4-b31a-63c1578dfd84.png)
Here's it in my Home Assistant client to show it's working.