### PR TITLE
Add sea level pressure calculation

### DIFF
--- a/documentation/boards/enviro-weather.md
+++ b/documentation/boards/enviro-weather.md
@@ -11,6 +11,7 @@ Enviro Weather is a super slimline all in one board for keeping a (weather) eye 
 |Temperature|`temperature`|celcius|°C|`22.11`|
 |Humidity|`humidity`|percent|%|`55.42`|
 |Air Pressure|`pressure`|hectopascals|hPa|`997.16`|
+|Adjusted Sea Level Air Pressure|`sea_level_pressure`|hectopascals|hPa|`1014.06`|
 |Luminance|`luminance`|lux|lx|`35`|
 |Rainfall|`rain`|millimetres|mm|`1.674`|
 |Rainfall Average|`rain_per_second`|millimetres per second|mm/s|`1.674`|

--- a/enviro/boards/weather.py
+++ b/enviro/boards/weather.py
@@ -191,8 +191,8 @@ def get_sensor_readings(seconds_since_last, is_usb_power):
   rain, rain_per_second = rainfall(seconds_since_last)
 
   # Adjust pressure to calculated sea level value if set to in config
-  pressure = round(bme280_data[1] / 100.0, 2)
-  temperature = round(bme280_data[0], 2)
+  pressure = bme280_data[1] / 100.0
+  temperature = bme280_data[0]
   
   if config.sea_level_pressure:
     logging.info(f"  - recorded temperature: {temperature}")
@@ -202,9 +202,9 @@ def get_sensor_readings(seconds_since_last, is_usb_power):
 
   from ucollections import OrderedDict
   return OrderedDict({
-    "temperature": temperature,
+    "temperature": round(temperature, 2),
     "humidity": round(bme280_data[2], 2),
-    "pressure": pressure,
+    "pressure": round(pressure, 2),
     "luminance": round(ltr_data[BreakoutLTR559.LUX], 2),
     "wind_speed": wind_speed(),
     "rain": rain,

--- a/enviro/boards/weather.py
+++ b/enviro/boards/weather.py
@@ -193,15 +193,9 @@ def get_sensor_readings(seconds_since_last, is_usb_power):
   # Adjust pressure to calculated sea level value if set to in config
   pressure = bme280_data[1] / 100.0
   temperature = bme280_data[0]
-  
-  if config.sea_level_pressure:
-    logging.info(f"  - recorded temperature: {temperature}")
-    logging.info(f"  - recorded pressure: {pressure}")
-    pressure = round(helpers.get_sea_level_pressure(pressure, temperature, config.height_above_sea_level), 2)
-    logging.info(f"  - calculated mean sea level pressure: {pressure}")
 
   from ucollections import OrderedDict
-  return OrderedDict({
+  readings = OrderedDict({
     "temperature": round(temperature, 2),
     "humidity": round(bme280_data[2], 2),
     "pressure": round(pressure, 2),
@@ -211,3 +205,12 @@ def get_sensor_readings(seconds_since_last, is_usb_power):
     "rain_per_second": rain_per_second,
     "wind_direction": wind_direction()
   })
+
+  if config.sea_level_pressure:
+    logging.info(f"  - recorded temperature: {temperature}")
+    logging.info(f"  - recorded pressure: {pressure}")
+    sea_level_pressure = round(helpers.get_sea_level_pressure(pressure, temperature, config.height_above_sea_level), 2)
+    logging.info(f"  - calculated mean sea level pressure: {sea_level_pressure}")
+    readings["sea_level_pressure"] = round(sea_level_pressure, 2)
+
+  return readings

--- a/enviro/config_defaults.py
+++ b/enviro/config_defaults.py
@@ -23,6 +23,19 @@ def add_missing_config_settings():
   except AttributeError:
     warn_missing_config_setting("wifi_country")
     config.wifi_country = "GB"
+  
+  try:
+    config.sea_level_pressure
+  except AttributeError:
+    warn_missing_config_setting("sea_level_pressure")
+    config.sea_level_pressure = False
+
+  try:
+    config.height_above_sea_level
+  except AttributeError:
+    warn_missing_config_setting("height_above_sea_level")
+    config.height_above_sea_level = 0
+
 
 def warn_missing_config_setting(setting):
     logging.warn(f"> config setting '{setting}' missing, please add it to config.py")

--- a/enviro/config_template.py
+++ b/enviro/config_template.py
@@ -55,3 +55,8 @@ moisture_target_c = 50
 
 # compensate for usb power
 usb_power_temperature_offset = 4.5
+
+# sea level pressure conversion (adjusts measured pressure output for mean sea level value)
+sea_level_pressure = False
+# height in metres
+height_above_sea_level = 0

--- a/enviro/helpers.py
+++ b/enviro/helpers.py
@@ -98,3 +98,10 @@ def get_saturation_vapor_pressure(temperature_in_k):
       temperature_in_k *
       (a1*v + a2*v**1.5 + a3*v**3 + a4*v**3.5 + a5*v**4 + a6*v**7.5)
   )
+
+# Calculates mean sea level pressure (QNH) from observed pressure
+# https://keisan.casio.com/exec/system/1224575267
+def get_sea_level_pressure(observed_pressure, temperature_in_c, altitude_in_m):
+# def sea(pressure, temperature, height):
+	qnh = observed_pressure * ((1 - ((0.0065 * altitude_in_m) / (temperature_in_c + (0.0065 * altitude_in_m) + 273.15)))** -5.257)
+	return qnh


### PR DESCRIPTION
This addresses #158 

Added two new parameters in config.py to adjust reported pressure to calculated sea level pressure and if enabled, what height the weather station is above sea level.

I believe I have correctly followed the config file backwards compatibility approach.

The code is only applied to the weather board as I only have that available to test, but the calculation is performed in the helpers.py file and I can add the conditional code to report the adjusted value to other boards if others would like to test in this PR.

I have confirmed that defaults are correctly applied if config.py is not correctly populated and that the calculated values match the source website calculator and synoptic chart expectations. There are log info messages to assist here, which appear when the sea level option is enabled.

I would like to add the option and height configuration to the provisioning code, but would need some design guidance on whether this is added to the nickname page (which makes the page title inaccurate) or adding a new intermediate page either with a x.5 title number or refactoring all pages to introduce a new number midway.

All feedback welcome.