### PR TITLE
Read all 16 possible wind direction values

### DIFF
--- a/enviro/boards/weather.py
+++ b/enviro/boards/weather.py
@@ -156,10 +156,10 @@ def wind_direction():
         closest_index = i
 
     resistance = (voltage * 10000) / (3.3 - voltage)
-    logging.info(f"> wind direction stats - voltage: {value}, resistance: {resistance}, closest value: {closest_value}, loops: {loop}")
+    logging.info(f"> wind direction stats - voltage: {value}, resistance: {resistance}, closest value: {closest_value}, closest index: {closest_index}, loops: {loop}")
 
-    # if True: #Test not waitng for two identical readings in a row
-    if last_index == closest_index:
+    if True: #Test not waitng for two identical readings in a row
+    # if last_index == closest_index:
       break
 
     last_index = closest_index

--- a/enviro/boards/weather.py
+++ b/enviro/boards/weather.py
@@ -137,9 +137,6 @@ def wind_direction():
   closest_index = -1
   last_index = None
 
-  # ensure we have two readings that match in a row as otherwise if
-  # you read during transition between two values it can glitch
-  # fixes https://github.com/pimoroni/enviro/issues/20
   voltage = 0.0
   
   value = wind_direction_pin.read_voltage()

--- a/enviro/boards/weather.py
+++ b/enviro/boards/weather.py
@@ -141,29 +141,20 @@ def wind_direction():
   # you read during transition between two values it can glitch
   # fixes https://github.com/pimoroni/enviro/issues/20
   voltage = 0.0
-  loop = 0
-  debug = []
-  while True:
-    value = wind_direction_pin.read_voltage()
+  
+  value = wind_direction_pin.read_voltage()
 
-    closest_index = -1
-    closest_value = float('inf')
+  closest_index = -1
+  closest_value = float('inf')
 
-    for i in range(16):
-      distance = abs(ADC_TO_DEGREES[i] - value)
-      if distance < closest_value:
-        closest_value = distance
-        closest_index = i
+  for i in range(16):
+    distance = abs(ADC_TO_DEGREES[i] - value)
+    if distance < closest_value:
+      closest_value = distance
+      closest_index = i
 
-    resistance = (voltage * 10000) / (3.3 - voltage)
-    logging.info(f"> wind direction stats - voltage: {value}, resistance: {resistance}, closest value: {closest_value}, closest index: {closest_index}, loops: {loop}")
-
-    if True: #Test not waitng for two identical readings in a row
-    # if last_index == closest_index:
-      break
-
-    last_index = closest_index
-    loop += 1
+  resistance = (voltage * 10000) / (3.3 - voltage)
+  logging.info(f"> wind direction stats - voltage: {value}, resistance: {resistance}, closest value: {closest_value}, closest index: {closest_index}")
 
   wind_direction = closest_index * 22.5
 

--- a/enviro/boards/weather.py
+++ b/enviro/boards/weather.py
@@ -3,7 +3,7 @@ from breakout_bme280 import BreakoutBME280
 from breakout_ltr559 import BreakoutLTR559
 from machine import Pin, PWM
 from pimoroni import Analog
-from enviro import i2c, activity_led
+from enviro import i2c, activity_led, config
 import enviro.helpers as helpers
 from phew import logging
 from enviro.constants import WAKE_REASON_RTC_ALARM, WAKE_REASON_BUTTON_PRESS
@@ -165,7 +165,11 @@ def wind_direction():
     last_index = closest_index
     loop += 1
 
-  return closest_index * 22.5
+  wind_direction = closest_index * 22.5
+
+  offset_wind_direction = (wind_direction + 360 + config.wind_direction_offset) % 360
+  
+  return offset_wind_direction
 
 def rainfall(seconds_since_last):
   amount = 0

--- a/enviro/boards/weather.py
+++ b/enviro/boards/weather.py
@@ -127,11 +127,12 @@ def wind_speed(sample_time_ms=1000):
 
 def wind_direction():
   # adc reading voltage to cardinal direction taken from our python
-  # library - each array index represents a 45 degree step around
-  # the compass (index 0 == 0, 1 == 45, 2 == 90, etc.)
+  # library - each array index represents a 22.5 degree step around
+  # the compass (index 0 == 0, 1 == 22.5, 2 == 45, etc.)
   # we find the closest matching value in the array and use the index
   # to determine the heading
-  ADC_TO_DEGREES = (0.9, 2.0, 3.0, 2.8, 2.5, 1.5, 0.3, 0.6)
+  ADC_TO_DEGREES = (2.533, 1.308, 1.487, 0.270, 0.300, 0.212, 0.595, 0.408,
+                    0.926, 0.789, 2.031, 1.932, 3.046, 2.667, 2.859, 2.265)
 
   closest_index = -1
   last_index = None
@@ -139,24 +140,32 @@ def wind_direction():
   # ensure we have two readings that match in a row as otherwise if
   # you read during transition between two values it can glitch
   # fixes https://github.com/pimoroni/enviro/issues/20
+  voltage = 0.0
+  loop = 0
+  debug = []
   while True:
     value = wind_direction_pin.read_voltage()
 
     closest_index = -1
     closest_value = float('inf')
 
-    for i in range(8):
+    for i in range(16):
       distance = abs(ADC_TO_DEGREES[i] - value)
       if distance < closest_value:
         closest_value = distance
         closest_index = i
 
+    resistance = (voltage * 10000) / (3.3 - voltage)
+    logging.info(f"> wind direction stats - voltage: {value}, resistance: {resistance}, closest value: {closest_value}, loops: {loop}")
+
+    # if True: #Test not waitng for two identical readings in a row
     if last_index == closest_index:
       break
 
     last_index = closest_index
+    loop += 1
 
-  return closest_index * 45
+  return closest_index * 22.5
 
 def rainfall(seconds_since_last):
   amount = 0

--- a/enviro/config_defaults.py
+++ b/enviro/config_defaults.py
@@ -2,7 +2,7 @@ import config
 from phew import logging
 
 DEFAULT_USB_POWER_TEMPERATURE_OFFSET = 4.5
-
+DEFAULT_WIND_DIRECTION_OFFSET = 0
 
 def add_missing_config_settings():
   try:
@@ -17,18 +17,18 @@ def add_missing_config_settings():
   except AttributeError:
     warn_missing_config_setting("usb_power_temperature_offset")
     config.usb_power_temperature_offset = DEFAULT_USB_POWER_TEMPERATURE_OFFSET
-
-  try:
-    config.wind_direction_offset
-  except AttributeError:
-    warn_missing_config_setting("wind_direction_offset")
-    config.wind_direction_offset = DEFAULT_USB_POWER_TEMPERATURE_OFFSET
-    
+  
   try:
     config.wifi_country
   except AttributeError:
     warn_missing_config_setting("wifi_country")
     config.wifi_country = "GB"
+
+  try:
+    config.wind_direction_offset
+  except AttributeError:
+    warn_missing_config_setting("wind_direction_offset")
+    config.wind_direction_offset = DEFAULT_WIND_DIRECTION_OFFSET
 
 def warn_missing_config_setting(setting):
     logging.warn(f"> config setting '{setting}' missing, please add it to config.py")

--- a/enviro/config_defaults.py
+++ b/enviro/config_defaults.py
@@ -19,6 +19,12 @@ def add_missing_config_settings():
     config.usb_power_temperature_offset = DEFAULT_USB_POWER_TEMPERATURE_OFFSET
 
   try:
+    config.wind_direction_offset
+  except AttributeError:
+    warn_missing_config_setting("wind_direction_offset")
+    config.wind_direction_offset = DEFAULT_USB_POWER_TEMPERATURE_OFFSET
+    
+  try:
     config.wifi_country
   except AttributeError:
     warn_missing_config_setting("wifi_country")

--- a/enviro/config_template.py
+++ b/enviro/config_template.py
@@ -55,3 +55,6 @@ moisture_target_c = 50
 
 # compensate for usb power
 usb_power_temperature_offset = 4.5
+
+# offset up to +/- 360 degrees for wind direction if you can't reorientate the weather station
+wind_direction_offset = 0


### PR DESCRIPTION
@ZodiusInfuser This is your code, so feel free to replace with your own PR, but this is the code tested in issue #114 to make it easier to further test and confirm changes made.

Loop to gain two matching consecutive readings was removed after testing, as it seems the errors were from intermediate readings not being understood by the 8 position code.

I have also added an optional offset value to the config file (with appropriate defaults and checks for older config files) as this code adjusts the reported value by 180 degrees to match the datasheet and some stations may not be readily physically adjusted.