### PR TITLE
Add rain per hour and day results

### DIFF
--- a/documentation/boards/enviro-weather.md
+++ b/documentation/boards/enviro-weather.md
@@ -20,7 +20,9 @@ Enviro Weather is a super slimline all in one board for keeping a (weather) eye 
 |Wind Speed|`wind_speed`|metres per second|m/s|`0.45`|
 |Voltage|`voltage`|volts|V|`4.035`|
 
-The rain today value is adjusted for local time (and/or DST) by modifying the utc_offset value in config.py
+The rain today value is adjusted for DST in the UK by setting uk_bst = True in config.py
+For static time zone offsets (not taking account of DST), modify the utc_offset value in config.py
+The time zone offset value is ignored if uk_bst = True
 
 ## On-board devices
 

--- a/documentation/boards/enviro-weather.md
+++ b/documentation/boards/enviro-weather.md
@@ -13,10 +13,14 @@ Enviro Weather is a super slimline all in one board for keeping a (weather) eye 
 |Air Pressure|`pressure`|hectopascals|hPa|`997.16`|
 |Luminance|`luminance`|lux|lx|`35`|
 |Rainfall|`rain`|millimetres|mm|`1.674`|
-|Rainfall Average|`rain_per_second`|millimetres per second|mm/s|`1.674`|
+|Rainfall Average Second|`rain_per_second`|millimetres per second|mm/s|`1.674`|
+|Rainfall Average Hour|`rain_per_hour`|millimetres per hour|mm/h|`1.674`|
+|Rainfall Today (local time)|`rain_today`|millimetres accumulated today|mm/s|`1.674`|
 |Wind Direction|`wind_direction`|angle|°|`45`|
 |Wind Speed|`wind_speed`|metres per second|m/s|`0.45`|
 |Voltage|`voltage`|volts|V|`4.035`|
+
+The rain today value is adjusted for local time (and/or DST) by modifying the utc_offset value in config.py
 
 ## On-board devices
 

--- a/enviro/boards/weather.py
+++ b/enviro/boards/weather.py
@@ -1,4 +1,4 @@
-import time, math, os
+import time, math, os, config
 from breakout_bme280 import BreakoutBME280
 from breakout_ltr559 import BreakoutLTR559
 from machine import Pin, PWM
@@ -152,7 +152,8 @@ def rainfall(seconds_since_last):
   per_hour = 0
   today = 0
   now = helpers.timestamp(helpers.datetime_string())
-  now_day = helpers.timestamp_day(helpers.datetime_string())
+  now_day = helpers.timestamp_day(helpers.datetime_string(), config.utc_offset)
+  logging.info(f"> current day number is {now_day}")
   if helpers.file_exists("rain.txt"):
     with open("rain.txt", "r") as rainfile:
       rain_entries = rainfile.read().split("\n")
@@ -161,7 +162,8 @@ def rainfall(seconds_since_last):
     for entry in rain_entries:
       if entry:
         ts = helpers.timestamp(entry)
-        tsday = helpers.timestamp_day(entry)
+        tsday = helpers.timestamp_day(entry, config.utc_offset)
+        logging.info(f"> rain reading day number is {tsday}")
         # count how many rain ticks since the last reading
         if now - ts < seconds_since_last:
           amount += RAIN_MM_PER_TICK

--- a/enviro/boards/weather.py
+++ b/enviro/boards/weather.py
@@ -165,6 +165,11 @@ def rainfall(seconds_since_last):
         # count how many rain ticks since the last reading
         if now - ts < seconds_since_last:
           amount += RAIN_MM_PER_TICK
+          # Pick up any untracked yesterday data if current reading is a new day
+          # Techincally this should be yesterday, but capturing in today is much
+          # less complex than backdating in the readings file from here
+          if tsday != now_day:
+            today += RAIN_MM_PER_TICK
         # count how many rain ticks in the last hour
         if now - ts < 3600:
           per_hour += RAIN_MM_PER_TICK

--- a/enviro/boards/weather.py
+++ b/enviro/boards/weather.py
@@ -151,8 +151,16 @@ def rainfall(seconds_since_last):
   amount = 0
   per_hour = 0
   today = 0
+  offset = 0
+  
+  if config.uk_bst == True:
+    if helpers.uk_bst():
+      offset = 1
+  elif config.utc_offset != 0:
+    offset += config.utc_offset
+
   now = helpers.timestamp(helpers.datetime_string())
-  now_day = helpers.timestamp_day(helpers.datetime_string(), config.utc_offset)
+  now_day = helpers.timestamp_day(helpers.datetime_string(), offset)
   logging.info(f"> current day number is {now_day}")
   if helpers.file_exists("rain.txt"):
     with open("rain.txt", "r") as rainfile:

--- a/enviro/config_defaults.py
+++ b/enviro/config_defaults.py
@@ -2,6 +2,8 @@ import config
 from phew import logging
 
 DEFAULT_USB_POWER_TEMPERATURE_OFFSET = 4.5
+DEFAULT_UTC_OFFSET = 0
+DEFAULT_UK_BST = True
 
 
 def add_missing_config_settings():
@@ -25,10 +27,16 @@ def add_missing_config_settings():
     config.wifi_country = "GB"
     
   try:
+    config.uk_bst
+  except AttributeError:
+    warn_missing_config_setting("uk_bst")
+    config.uk_bst = DEFAULT_UK_BST
+
+  try:
     config.utc_offset
   except AttributeError:
     warn_missing_config_setting("utc_offset")
-    config.utc_offset = 0
+    config.utc_offset = DEFAULT_UTC_OFFSET
 
 def warn_missing_config_setting(setting):
     logging.warn(f"> config setting '{setting}' missing, please add it to config.py")

--- a/enviro/config_defaults.py
+++ b/enviro/config_defaults.py
@@ -23,6 +23,12 @@ def add_missing_config_settings():
   except AttributeError:
     warn_missing_config_setting("wifi_country")
     config.wifi_country = "GB"
+    
+  try:
+    config.utc_offset
+  except AttributeError:
+    warn_missing_config_setting("utc_offset")
+    config.utc_offset = 0
 
 def warn_missing_config_setting(setting):
     logging.warn(f"> config setting '{setting}' missing, please add it to config.py")

--- a/enviro/config_template.py
+++ b/enviro/config_template.py
@@ -13,8 +13,12 @@ wifi_ssid = None
 wifi_password = None
 wifi_country = "GB"
 
-# For local time corrections to daily rain logging (include DST)
-utc_offset = 1
+# Adjust daily rain day for UK BST
+uk_bst = True
+
+# For local time corrections to daily rain logging other than BST
+# Ignored if uk_bst = True
+utc_offset = 0
 
 # how often to wake up and take a reading (in minutes)
 reading_frequency = 15

--- a/enviro/config_template.py
+++ b/enviro/config_template.py
@@ -13,6 +13,9 @@ wifi_ssid = None
 wifi_password = None
 wifi_country = "GB"
 
+# For local time corrections to daily rain logging (include DST)
+utc_offset = 1
+
 # how often to wake up and take a reading (in minutes)
 reading_frequency = 15
 

--- a/enviro/helpers.py
+++ b/enviro/helpers.py
@@ -1,5 +1,6 @@
 from enviro.constants import *
 import machine, math, os, time, utime
+from phew import logging
 
 # miscellany
 # ===========================================================================
@@ -23,6 +24,32 @@ def timestamp(dt):
   minute = int(dt[14:16])
   second = int(dt[17:19])
   return time.mktime((year, month, day, hour, minute, second, 0, 0))
+
+def uk_bst():
+  # Return True if in UK BST - manually update bst_timestamps {} as needed
+  dt = datetime_string()
+  year = int(dt[0:4])
+  ts = timestamp(dt)
+  bst = False
+
+  bst_timestamps = {
+    2023: {"start": 1679792400, "end": 1698541200},
+    2024: {"start": 1711846800, "end": 1729990800},
+    2025: {"start": 1743296400, "end": 1761440400},
+    2026: {"start": 1774746000, "end": 1792890000},
+    2027: {"start": 1806195600, "end": 1824944400},
+    2028: {"start": 1837645200, "end": 1856394000},
+    2029: {"start": 1869094800, "end": 1887843600},
+    2030: {"start": 1901149200, "end": 1919293200}
+  }
+
+  if year in bst_timestamps:
+    if bst_timestamps[year]["start"] < ts and bst_timestamps[year]["end"] > ts:
+      bst = True
+  else:
+    logging.warn(f"> Provided year is not in BST lookup dictionary: {year}")
+  return bst
+  
 
 # Return the day number of your timestamp string accommodating UTC offsets
 def timestamp_day(dt, offset_hours):

--- a/enviro/helpers.py
+++ b/enviro/helpers.py
@@ -24,6 +24,10 @@ def timestamp(dt):
   second = int(dt[17:19])
   return time.mktime((year, month, day, hour, minute, second, 0, 0))
 
+def timestamp_day(dt):
+  day = int(dt[8:10])
+  return day
+
 def uid():
   return "{:02x}{:02x}{:02x}{:02x}{:02x}{:02x}{:02x}{:02x}".format(*machine.unique_id())
 

--- a/enviro/helpers.py
+++ b/enviro/helpers.py
@@ -1,5 +1,5 @@
 from enviro.constants import *
-import machine, math, os, time
+import machine, math, os, time, utime
 
 # miscellany
 # ===========================================================================
@@ -24,8 +24,13 @@ def timestamp(dt):
   second = int(dt[17:19])
   return time.mktime((year, month, day, hour, minute, second, 0, 0))
 
-def timestamp_day(dt):
-  day = int(dt[8:10])
+# Return the day number of your timestamp string accommodating UTC offsets
+def timestamp_day(dt, offset_hours):
+  # Bounce via timestamp to properly calculate hours change
+  time = timestamp(dt)
+  time = time + (offset_hours * 3600)
+  dt = utime.localtime(time)
+  day = int(dt[2])
   return day
 
 def uid():

--- a/enviro/helpers.py
+++ b/enviro/helpers.py
@@ -47,7 +47,7 @@ def uk_bst():
     if bst_timestamps[year]["start"] < ts and bst_timestamps[year]["end"] > ts:
       bst = True
   else:
-    logging.warn(f"> Provided year is not in BST lookup dictionary: {year}")
+    logging.warn(f"> Current year is not in BST lookup dictionary: {year}")
   return bst
   
 


### PR DESCRIPTION
To address #168 adding readings for rain per hour and rain today.

rain_per_hour: sum of rain logged in the last 60 minutes
rain_today: rain logged since midnight

Removed the line to delete the rain file after taking a reading.
Added two IFs to count timestamps for the last hour and for today
Only write back values to the file from today as older values no longer needed.

I created a new function log_rain() to reduce the duplication in startup() and check_trigger() as I thought I would update that block. But as we will check much more regularly than daily, there was no need to remove older readings here, but I kept the function anyway.

I have tested by grounding the rain pin and manipulating the rain file to make entries appear 2 hours ago and yesterday and works as expected. Will run the code in the wild to try and catch some real rain over time.