### PR TITLE
Do not accept wrong dates (e.g. 2080)

### DIFF
--- a/enviro/__init__.py
+++ b/enviro/__init__.py
@@ -226,8 +226,8 @@ def low_disk_space():
 
 # returns True if the rtc clock has been set recently 
 def is_clock_set():
-  # is the year on or before 2020?
-  if rtc.datetime()[0] <= 2020:
+  # is the year on or before 2020 or after 2050?
+  if rtc.datetime()[0] <= 2020 or rtc.datetime()[0] >= 2050:
     return False
 
   if helpers.file_exists("sync_time.txt"):


### PR DESCRIPTION
I experienced multiple times a glitch in ntp sync that resulted in setting the date to year 2080. This is a quick dirty fix to mitigate the issue and let the system run the sync again