### PR TITLE
Weather battery temperature compensation

### DIFF
--- a/enviro/boards/weather.py
+++ b/enviro/boards/weather.py
@@ -202,7 +202,7 @@ def get_sensor_readings(seconds_since_last, is_usb_power):
     logging.info(f"  - USB temperature offset: {config.usb_power_temperature_offset}")
   else:
     adjusted_temperature = temperature - config.battery_power_temperature_offset
-    logging.info(f"  - Battery temperature offset: {config.usb_power_temperature_offset}")
+    logging.info(f"  - Battery temperature offset: {config.battery_power_temperature_offset}")
   absolute_humidity = helpers.relative_to_absolute_humidity(humidity, temperature)
   humidity = helpers.absolute_to_relative_humidity(absolute_humidity, adjusted_temperature)
   temperature = adjusted_temperature

--- a/enviro/boards/weather.py
+++ b/enviro/boards/weather.py
@@ -3,7 +3,7 @@ from breakout_bme280 import BreakoutBME280
 from breakout_ltr559 import BreakoutLTR559
 from machine import Pin, PWM
 from pimoroni import Analog
-from enviro import i2c, activity_led
+from enviro import i2c, activity_led, config
 import enviro.helpers as helpers
 from phew import logging
 from enviro.constants import WAKE_REASON_RTC_ALARM, WAKE_REASON_BUTTON_PRESS
@@ -190,10 +190,25 @@ def get_sensor_readings(seconds_since_last, is_usb_power):
   ltr_data = ltr559.get_reading()
   rain, rain_per_second = rainfall(seconds_since_last)
 
+  temperature = bme280_data[0]
+  humidity = bme280_data[2]
+
+  # Compensate for additional heating when on usb power - this also changes the
+  # relative humidity value.
+  if is_usb_power:
+    logging.info(f"  - recorded temperature: {temperature}")
+    logging.info(f"  - recorded humidity: {humidity}")
+    adjusted_temperature = temperature - config.usb_power_temperature_offset
+    absolute_humidity = helpers.relative_to_absolute_humidity(humidity, temperature)
+    humidity = helpers.absolute_to_relative_humidity(absolute_humidity, adjusted_temperature)
+    temperature = adjusted_temperature
+    logging.info(f"  - USB adjusted temperature: {temperature}")
+    logging.info(f"  - USB adjusted humidity: {humidity}")
+
   from ucollections import OrderedDict
   return OrderedDict({
-    "temperature": round(bme280_data[0], 2),
-    "humidity": round(bme280_data[2], 2),
+    "temperature": round(temperature, 2),
+    "humidity": round(humidity, 2),
     "pressure": round(bme280_data[1] / 100.0, 2),
     "luminance": round(ltr_data[BreakoutLTR559.LUX], 2),
     "wind_speed": wind_speed(),

--- a/enviro/boards/weather.py
+++ b/enviro/boards/weather.py
@@ -193,17 +193,21 @@ def get_sensor_readings(seconds_since_last, is_usb_power):
   temperature = bme280_data[0]
   humidity = bme280_data[2]
 
-  # Compensate for additional heating when on usb power - this also changes the
-  # relative humidity value.
+  # Compensate for additional heating when on different power sources - this
+  # also changes the relative humidity value
+  logging.info(f"  - recorded temperature: {temperature}")
+  logging.info(f"  - recorded humidity: {humidity}")
   if is_usb_power:
-    logging.info(f"  - recorded temperature: {temperature}")
-    logging.info(f"  - recorded humidity: {humidity}")
     adjusted_temperature = temperature - config.usb_power_temperature_offset
-    absolute_humidity = helpers.relative_to_absolute_humidity(humidity, temperature)
-    humidity = helpers.absolute_to_relative_humidity(absolute_humidity, adjusted_temperature)
-    temperature = adjusted_temperature
-    logging.info(f"  - USB adjusted temperature: {temperature}")
-    logging.info(f"  - USB adjusted humidity: {humidity}")
+    logging.info(f"  - USB temperature offset: {config.usb_power_temperature_offset}")
+  else:
+    adjusted_temperature = temperature - config.battery_power_temperature_offset
+    logging.info(f"  - Battery temperature offset: {config.usb_power_temperature_offset}")
+  absolute_humidity = helpers.relative_to_absolute_humidity(humidity, temperature)
+  humidity = helpers.absolute_to_relative_humidity(absolute_humidity, adjusted_temperature)
+  temperature = adjusted_temperature
+  logging.info(f"  - adjusted temperature: {temperature}")
+  logging.info(f"  - adjusted humidity: {humidity}")
 
   from ucollections import OrderedDict
   return OrderedDict({

--- a/enviro/config_defaults.py
+++ b/enviro/config_defaults.py
@@ -2,6 +2,7 @@ import config
 from phew import logging
 
 DEFAULT_USB_POWER_TEMPERATURE_OFFSET = 4.5
+DEFAULT_BATTERY_POWER_TEMPERATURE_OFFSET = 2.0
 
 
 def add_missing_config_settings():
@@ -17,6 +18,12 @@ def add_missing_config_settings():
   except AttributeError:
     warn_missing_config_setting("usb_power_temperature_offset")
     config.usb_power_temperature_offset = DEFAULT_USB_POWER_TEMPERATURE_OFFSET
+  
+  try:
+    config.battery_power_temperature_offset
+  except AttributeError:
+    warn_missing_config_setting("battery_power_temperature_offset")
+    config.battery_power_temperature_offset = DEFAULT_BATTERY_POWER_TEMPERATURE_OFFSET
 
 
 def warn_missing_config_setting(setting):

--- a/enviro/config_defaults.py
+++ b/enviro/config_defaults.py
@@ -2,7 +2,7 @@ import config
 from phew import logging
 
 DEFAULT_USB_POWER_TEMPERATURE_OFFSET = 4.5
-DEFAULT_BATTERY_POWER_TEMPERATURE_OFFSET = 2.0
+DEFAULT_BATTERY_POWER_TEMPERATURE_OFFSET = 0.0
 
 
 def add_missing_config_settings():

--- a/enviro/config_template.py
+++ b/enviro/config_template.py
@@ -52,5 +52,11 @@ moisture_target_a = 50
 moisture_target_b = 50
 moisture_target_c = 50
 
-# compensate for usb power - degrees to remove from measured temperature
+# compensate for usb power
+# degrees to remove from measured temperature when running on USB
 usb_power_temperature_offset = 4.5
+
+# compensate for battery power (only on weather boards)
+# degrees to remove from measured temperature when running on battery
+# this will vary based on poll and wifi upload frequency with accumulated heat as these values increase
+battery_power_temperature_offset = 2.0

--- a/enviro/config_template.py
+++ b/enviro/config_template.py
@@ -59,4 +59,4 @@ usb_power_temperature_offset = 4.5
 # compensate for battery power (only on weather boards)
 # degrees to remove from measured temperature when running on battery
 # this will vary based on poll and wifi upload frequency with accumulated heat as these values increase
-battery_power_temperature_offset = 2.0
+battery_power_temperature_offset = 0.0

--- a/enviro/config_template.py
+++ b/enviro/config_template.py
@@ -52,5 +52,5 @@ moisture_target_a = 50
 moisture_target_b = 50
 moisture_target_c = 50
 
-# compensate for usb power
+# compensate for usb power - degrees to remove from measured temperature
 usb_power_temperature_offset = 4.5


### PR DESCRIPTION
Adds a config option for an offset when running on battery for the weather board. This extends the work done on PR #160 to add USB offset to weather board.

Get readings on the weather board will always apply a correction and selects either USB or battery value from the config file.
This does assume the value is available and uses the existing config file framework to apply defaults and warn in the log if missing to prevent a crash if not actively configured.

Default value is 0 as most users will not be polling at a frequency that should cause this issue and it is not in the setup web pages.

I have tested on USB and battery with the weather board to ensure the logic works as expected.

Deploying outdoors for long term testing, I have also upgraded to the Pimoroni Enviro v1.20.3 firmware for this and my other PRs for long term stability testing, so far so good.

This addresses issue #185 