### PR TITLE
Secondary upload destination

### DIFF
--- a/enviro/__init__.py
+++ b/enviro/__init__.py
@@ -428,8 +428,9 @@ def upload_readings():
       try:
         with open(f"uploads/{cache_file[0]}", "r") as upload_file:
           filename = cache_file[0]
+          json = ujson.load(upload_file)
           destination_module.log_destination()
-          status = destination_module.upload_reading(ujson.load(upload_file))
+          status = destination_module.upload_reading(json)
           # Delete if primary upload succeeds regardless of secondary - prioritise stability over data coverage
           # This will mean multiple uploads to secondary if primary fails - may need to improve destination success management dpeending on destination duplicate handling
           if status == UPLOAD_SUCCESS:
@@ -463,7 +464,7 @@ def upload_readings():
             return False
           
           secondary_destination_module.log_destination()
-          secondary_status = secondary_destination_module.upload_reading(ujson.load(upload_file))
+          secondary_status = secondary_destination_module.upload_reading(json)
           if secondary_status == UPLOAD_SUCCESS:
             logging.info(f"  - Secondary destination upload success for {filename}")
 

--- a/enviro/__init__.py
+++ b/enviro/__init__.py
@@ -420,26 +420,22 @@ def upload_readings():
   try:
     exec(f"import enviro.destinations.{destination}")
     destination_module = sys.modules[f"enviro.destinations.{destination}"]
-    destination_module.log_destination()
     
     exec(f"import enviro.destinations.{secondary_destination}")
     secondary_destination_module = sys.modules[f"enviro.destinations.{secondary_destination}"]
-    secondary_destination_module.log_destination()
 
     for cache_file in os.ilistdir("uploads"):
       try:
         with open(f"uploads/{cache_file[0]}", "r") as upload_file:
+          filename = cache_file[0]
+          destination_module.log_destination()
           status = destination_module.upload_reading(ujson.load(upload_file))
-          if status == UPLOAD_SUCCESS:
-            logging.info(f"  - Primary destination upload success for {cache_file[0]}")
-          secondary_status = secondary_destination_module.upload_reading(ujson.load(upload_file))
-          if secondary_status == UPLOAD_SUCCESS:
-            logging.info(f"  - Secondary destination upload success for {cache_file[0]}")
           # Delete if primary upload succeeds regardless of secondary - prioritise stability over data coverage
           # This will mean multiple uploads to secondary if primary fails - may need to improve destination success management dpeending on destination duplicate handling
           if status == UPLOAD_SUCCESS:
+            logging.info(f"  - Primary destination upload success for {filename}")
             os.remove(f"uploads/{cache_file[0]}")
-            logging.info(f"  - uploaded {cache_file[0]}")
+            logging.info(f"  - removing file {cache_file[0]}")
           elif status == UPLOAD_RATE_LIMITED:
             # write out that we want to attempt a reupload
             with open("reattempt_upload.txt", "w") as attemptfile:
@@ -465,6 +461,11 @@ def upload_readings():
           else:
             logging.error(f"  ! failed to upload '{cache_file[0]}' to {destination}")
             return False
+          
+          secondary_destination_module.log_destination()
+          secondary_status = secondary_destination_module.upload_reading(ujson.load(upload_file))
+          if secondary_status == UPLOAD_SUCCESS:
+            logging.info(f"  - Secondary destination upload success for {filename}")
 
       except OSError:
         logging.error(f"  ! failed to open '{cache_file[0]}'")

--- a/enviro/config_defaults.py
+++ b/enviro/config_defaults.py
@@ -2,7 +2,7 @@ import config
 from phew import logging
 
 DEFAULT_USB_POWER_TEMPERATURE_OFFSET = 4.5
-
+DEFAULT_SECONDARY_DESTINATION = None
 
 def add_missing_config_settings():
   try:
@@ -17,6 +17,12 @@ def add_missing_config_settings():
   except AttributeError:
     warn_missing_config_setting("usb_power_temperature_offset")
     config.usb_power_temperature_offset = DEFAULT_USB_POWER_TEMPERATURE_OFFSET
+  
+  try:
+    config.secondary_destination
+  except AttributeError:
+    warn_missing_config_setting("secondary_destination")
+    config.secondary_destination = DEFAULT_SECONDARY_DESTINATION
 
 
 def warn_missing_config_setting(setting):

--- a/enviro/config_template.py
+++ b/enviro/config_template.py
@@ -20,6 +20,12 @@ resync_frequency = 168
 
 # where to upload to ("http", "mqtt", "adafruit_io", "influxdb")
 destination = None
+# Optional secondary destination - this will consume more battery
+# Cached uploads cleanup occurs only on primary destination success, this means
+# secondary data will not retry if primary is successful, also secondary data
+# will be reuploaded if the primary fails, ensure the secondary destination can
+# handle duplicate uploads
+secondary_destination = None
 
 # how often to upload data (number of cached readings)
 upload_frequency = 5


### PR DESCRIPTION
Add a secondary upload destination in the config file that defaults to None.

Modified the \_\_init\_\_.py upload readings function to have a stab at the secondary upload once the full set of primary attempts are complete.

The secondary will not retry data if the primary is successful and equally the secondary will receive duplicates if the primary experiences issues on the previous pass.

This is designed to allow me to get extra diagnostic data to my influxdb while not interrupting the Wunderground data upload.

The above could be improved with better error handling logic if there is demand.

This makes improvements in the direction requested in #38 for more concurrent destinations.