### PR TITLE
Batch local readings by day

### DIFF
--- a/enviro/__init__.py
+++ b/enviro/__init__.py
@@ -367,7 +367,7 @@ def get_sensor_readings():
 def save_reading(readings):
   # open todays reading file and save readings
   helpers.mkdir_safe("readings")
-  readings_filename = f"readings/{helpers.datetime_file_string()}.txt"
+  readings_filename = f"readings/{helpers.date_string()}.txt"
   new_file = not helpers.file_exists(readings_filename)
   with open(readings_filename, "a") as f:
     if new_file:


### PR DESCRIPTION
When Enviro is configured to not upload data, store readings locally, with readings grouped into one file per day.

See issue #193