### PR TITLE
Updated version number to reflect release

### DIFF
--- a/enviro/constants.py
+++ b/enviro/constants.py
@@ -1,5 +1,5 @@
 # version
-ENVIRO_VERSION = "0.0.10" 
+ENVIRO_VERSION = "0.2.0" 
  
 # modules
 ENVIRO_UNKNOWN                = None


### PR DESCRIPTION
Updated `ENVIRO_VERSION` to reflect the current release version (to avoid not-inconsiderable confusion when people upgrade and then tell me they're on 0.0.10... :laughing: )