### PR TITLE
CI: Bump base firmware to v1.23.0.

### DIFF
--- a/.github/workflows/release-zip.yml
+++ b/.github/workflows/release-zip.yml
@@ -13,8 +13,8 @@ jobs:
 
     env:
       RELEASE_FILE: enviro-${{github.event.release.tag_name || github.sha}}
-      FIRMWARE_NAME: pimoroni-enviro-v1.22.2-micropython
-      FIRMWARE_URL: https://github.com/pimoroni/pimoroni-pico/releases/download/v1.22.2
+      FIRMWARE_NAME: enviro-v1.23.0-pimoroni-micropython
+      FIRMWARE_URL: https://github.com/pimoroni/pimoroni-pico/releases/download/v1.23.0
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
This is a test build for evaluating Enviro firmware on the latest release of MicroPython.

See release notes for Pimoroni Pico (and links through to other related notes) here: https://github.com/pimoroni/pimoroni-pico/releases/tag/v1.23.0