### PR TITLE
Make board files more uniform, bring usb temperature adjustments to all boards

### DIFF
--- a/enviro/boards/grow.py
+++ b/enviro/boards/grow.py
@@ -1,15 +1,24 @@
+# imports common to all boards
+from enviro import config
+import enviro.helpers as helpers
+from enviro import i2c
+from ucollections import OrderedDict
+
+# board specific imports
 import time
 from breakout_bme280 import BreakoutBME280
 from breakout_ltr559 import BreakoutLTR559
 from machine import Pin, PWM
-from enviro import i2c
 from phew import logging
 
+# board specific global constants
 CHANNEL_NAMES = ['A', 'B', 'C']
 
+# board specific sensors
 bme280 = BreakoutBME280(i2c, 0x77)
 ltr559 = BreakoutLTR559(i2c)
 
+# board specific pins
 piezo_pwm = PWM(Pin(28))
 
 moisture_sensor_pins = [
@@ -24,6 +33,7 @@ pump_pins = [
   Pin(10, Pin.OUT, value=0)
 ]
 
+# define functions
 def moisture_readings():
   results = []
 
@@ -73,7 +83,6 @@ def drip_noise():
   piezo_pwm.duty_u16(0)
 
 def water(moisture_levels):
-  from enviro import config
   targets = [
     config.moisture_target_a, 
     config.moisture_target_b,
@@ -105,21 +114,33 @@ def get_sensor_readings(seconds_since_last, is_usb_power):
   time.sleep(0.1)
   bme280_data = bme280.read()
 
-  ltr_data = ltr559.get_reading()
+  temperature = round(bme280_data[0], 2)
+  pressure = round(bme280_data[1] / 100.0, 2)
+  humidity = round(bme280_data[2], 2)
+  
+  # Compensate for additional heating when on usb power - this also changes the
+  # relative humidity value.
+  if is_usb_power:
+    adjusted_temperature = temperature - config.usb_power_temperature_offset
+    absolute_humidity = helpers.relative_to_absolute_humidity(humidity, temperature)
+    humidity = helpers.absolute_to_relative_humidity(absolute_humidity, adjusted_temperature)
+    temperature = adjusted_temperature
 
-  moisture_levels = moisture_readings()
+  ltr_data = ltr559.get_reading()
+  luminance = round(ltr_data[BreakoutLTR559.LUX], 2)
+
+  moisture_levels = [round(lvl,2) for lvl in moisture_readings()]
 
   water(moisture_levels) # run pumps if needed
 
-  from ucollections import OrderedDict
   return OrderedDict({
-    "temperature": round(bme280_data[0], 2),
-    "humidity": round(bme280_data[2], 2),
-    "pressure": round(bme280_data[1] / 100.0, 2),
-    "luminance": round(ltr_data[BreakoutLTR559.LUX], 2),
-    "moisture_a": round(moisture_levels[0], 2),
-    "moisture_b": round(moisture_levels[1], 2),
-    "moisture_c": round(moisture_levels[2], 2)
+    "temperature": temperature,
+    "humidity": humidity,
+    "pressure": pressure,
+    "luminance": luminance,
+    "moisture_a": moisture_levels[0],
+    "moisture_b": moisture_levels[1],
+    "moisture_c": moisture_levels[2]
   })
   
 def play_tone(frequency = None):

--- a/enviro/boards/indoor.py
+++ b/enviro/boards/indoor.py
@@ -1,11 +1,17 @@
+# imports common to all boards
+from enviro import config
 import enviro.helpers as helpers
+from enviro import i2c
+from ucollections import OrderedDict
+
+# board specific imports
 import math
 from breakout_bme68x import BreakoutBME68X
 from breakout_bh1745 import BreakoutBH1745
 
-from enviro import config
-from enviro import i2c
+# board specific global constants
 
+# board specific sensors
 bme688 = BreakoutBME68X(i2c, address=0x77)
 
 bh1745 = BreakoutBH1745(i2c)
@@ -13,6 +19,9 @@ bh1745 = BreakoutBH1745(i2c)
 # reports bad results (this is undocumented...)
 i2c.writeto_mem(0x38, 0x44, b'\x02')
 
+# board specific pins
+
+# define functions
 def lux_from_rgbc(r, g, b, c):
   if g < 1:
       tmp = 0
@@ -43,11 +52,13 @@ def colour_temperature_from_rgbc(r, g, b, c):
   return round(ct)
 
 def get_sensor_readings(seconds_since_last, is_usb_power):
-  data = bme688.read()
+  bme688_data = bme688.read()
 
-  temperature = round(data[0], 2)
-  humidity = round(data[2], 2)
 
+  temperature = round(bme688_data[0], 2)
+  pressure = round(bme688_data[1] / 100.0, 2)
+  humidity = round(bme688_data[2], 2)
+  
   # Compensate for additional heating when on usb power - this also changes the
   # relative humidity value.
   if is_usb_power:
@@ -55,9 +66,7 @@ def get_sensor_readings(seconds_since_last, is_usb_power):
     absolute_humidity = helpers.relative_to_absolute_humidity(humidity, temperature)
     humidity = helpers.absolute_to_relative_humidity(absolute_humidity, adjusted_temperature)
     temperature = adjusted_temperature
-
-  pressure = round(data[1] / 100.0, 2)
-  gas_resistance = round(data[3])
+  gas_resistance = round(bme688_data[3])
   # an approximate air quality calculation that accounts for the effect of
   # humidity on the gas sensor
   # https://forums.pimoroni.com/t/bme680-observed-gas-ohms-readings/6608/25
@@ -65,14 +74,15 @@ def get_sensor_readings(seconds_since_last, is_usb_power):
 
   bh1745.measurement_time_ms(160)
   r, g, b, c = bh1745.rgbc_raw()
-
-  from ucollections import OrderedDict
+  luminance = lux_from_rgbc(r, g, b, c)
+  color_temperature = colour_temperature_from_rgbc(r, g, b, c)
+  
   return OrderedDict({
     "temperature": temperature,
     "humidity": humidity,
     "pressure": pressure,
     "gas_resistance": gas_resistance,
     "aqi": aqi,
-    "luminance": lux_from_rgbc(r, g, b, c),
-    "color_temperature": colour_temperature_from_rgbc(r, g, b, c)
+    "luminance": luminance,
+    "color_temperature": color_temperature
   })

--- a/enviro/boards/urban.py
+++ b/enviro/boards/urban.py
@@ -1,21 +1,28 @@
-import time, math
+# imports common to all boards
+from enviro import config
+import enviro.helpers as helpers
+from enviro import i2c
+from ucollections import OrderedDict
+
+# board specific imports
+import time
 from machine import Pin, ADC
 from breakout_bme280 import BreakoutBME280
 from pimoroni_i2c import PimoroniI2C
 from phew import logging
-from enviro import i2c
 
+# board specific global constants
 # how long to capture the microphone signal for when taking a reading, in milliseconds
 MIC_SAMPLE_TIME_MS = 500
 
+# board specific sensors
+bme280 = BreakoutBME280(i2c, 0x77)
+noise_adc = ADC(0)
+
+# board specific pins
 sensor_reset_pin = Pin(9, Pin.OUT, value=True)
 sensor_enable_pin = Pin(10, Pin.OUT, value=False)
 boost_enable_pin = Pin(11, Pin.OUT, value=False)
-
-noise_adc = ADC(0)
-
-bme280 = BreakoutBME280(i2c, 0x77)
-
 PM1_UGM3                = 2
 PM2_5_UGM3              = 3
 PM10_UGM3               = 4
@@ -29,6 +36,7 @@ PM2_5_PER_LITRE         = 11
 PM5_PER_LITRE           = 12
 PM10_PER_LITRE          = 13
 
+# define functions
 def particulates(particulate_data, measure):
   # bit of a fudge to convert decilitres into litres... who uses decilitre?!
   multiplier = 10 if measure >= PM0_3_PER_LITRE else 1
@@ -40,7 +48,19 @@ def get_sensor_readings(seconds_since_last, is_usb_power):
   bme280.read()
   time.sleep(0.1)
   bme280_data = bme280.read()
+
+  temperature = round(bme280_data[0], 2)
+  pressure = round(bme280_data[1] / 100.0, 2)
+  humidity = round(bme280_data[2], 2)
   
+  # Compensate for additional heating when on usb power - this also changes the
+  # relative humidity value.
+  if is_usb_power:
+    adjusted_temperature = temperature - config.usb_power_temperature_offset
+    absolute_humidity = helpers.relative_to_absolute_humidity(humidity, temperature)
+    humidity = helpers.absolute_to_relative_humidity(absolute_humidity, adjusted_temperature)
+    temperature = adjusted_temperature
+    
   logging.debug("  - starting sensor")
   boost_enable_pin.value(True)
   sensor_enable_pin.value(True)
@@ -51,6 +71,9 @@ def get_sensor_readings(seconds_since_last, is_usb_power):
   logging.debug("  - taking pms5003i reading")
   pms_i2c = PimoroniI2C(14, 15, 100000)
   particulate_data = pms_i2c.readfrom_mem(0x12, 0x00, 32)
+  pm1 = particulates(particulate_data, PM1_UGM3)
+  pm2_5 = particulates(particulate_data, PM2_5_UGM3) 
+  pm10 = particulates(particulate_data, PM10_UGM3)
 
   sensor_enable_pin.value(False)
   boost_enable_pin.value(False)
@@ -65,15 +88,15 @@ def get_sensor_readings(seconds_since_last, is_usb_power):
     max_value = max(max_value, value)
   
   noise_vpp = max_value - min_value
+  noise = round(noise_vpp, 3)
 
-  from ucollections import OrderedDict
+
   return OrderedDict({
-    "temperature": round(bme280_data[0], 2),
-    "humidity": round(bme280_data[2], 2),
-    "pressure": round(bme280_data[1] / 100.0, 2),
-    "noise": round(noise_vpp, 3),
-    "pm1": particulates(particulate_data, PM1_UGM3), 
-    "pm2_5": particulates(particulate_data, PM2_5_UGM3), 
-    "pm10": particulates(particulate_data, PM10_UGM3)
+    "temperature": temperature,
+    "humidity": humidity,
+    "pressure": pressure,
+    "noise": noise,
+    "pm1": pm1, 
+    "pm2_5": pm2_5, 
+    "pm10": pm10
   })
-

--- a/enviro/boards/weather.py
+++ b/enviro/boards/weather.py
@@ -1,33 +1,41 @@
-import time, math, os
+# imports common to all boards
+from enviro import config
+import enviro.helpers as helpers
+from enviro import i2c
+from ucollections import OrderedDict
+
+# board specific imports
+import time, math, os, wakeup
 from breakout_bme280 import BreakoutBME280
 from breakout_ltr559 import BreakoutLTR559
 from machine import Pin, PWM
 from pimoroni import Analog
-from enviro import i2c, activity_led
-import enviro.helpers as helpers
+from enviro import activity_led
 from phew import logging
 from enviro.constants import WAKE_REASON_RTC_ALARM, WAKE_REASON_BUTTON_PRESS
 
+# board specific global constants
 # amount of rain required for the bucket to tip in mm
 RAIN_MM_PER_TICK = 0.2794
-
 # distance from the centre of the anemometer to the centre 
 # of one of the cups in cm
 WIND_CM_RADIUS = 7.0
 # scaling factor for wind speed in m/s
 WIND_FACTOR = 0.0218
 
+# board specific sensors
 bme280 = BreakoutBME280(i2c, 0x77)
 ltr559 = BreakoutLTR559(i2c)
 
+# board specific pins
 wind_direction_pin = Analog(26)
 wind_speed_pin = Pin(9, Pin.IN, Pin.PULL_UP)
 rain_pin = Pin(10, Pin.IN, Pin.PULL_DOWN)
 last_rain_trigger = False
 
+# Define functions
 def startup(reason):
   global last_rain_trigger
-  import wakeup
 
   # check if rain sensor triggered wake
   rain_sensor_trigger = wakeup.get_gpio_state() & (1 << 10)
@@ -187,15 +195,28 @@ def get_sensor_readings(seconds_since_last, is_usb_power):
   time.sleep(0.1)
   bme280_data = bme280.read()
 
+  temperature = round(bme280_data[0], 2)
+  pressure = round(bme280_data[1] / 100.0, 2)
+  humidity = round(bme280_data[2], 2)
+
+  # Compensate for additional heating when on usb power - this also changes the
+  # relative humidity value.
+  if is_usb_power:
+    adjusted_temperature = temperature - config.usb_power_temperature_offset
+    absolute_humidity = helpers.relative_to_absolute_humidity(humidity, temperature)
+    humidity = helpers.absolute_to_relative_humidity(absolute_humidity, adjusted_temperature)
+    temperature = adjusted_temperature
+  
   ltr_data = ltr559.get_reading()
+  luminance = round(ltr_data[BreakoutLTR559.LUX], 2)
+
   rain, rain_per_second = rainfall(seconds_since_last)
 
-  from ucollections import OrderedDict
   return OrderedDict({
-    "temperature": round(bme280_data[0], 2),
-    "humidity": round(bme280_data[2], 2),
-    "pressure": round(bme280_data[1] / 100.0, 2),
-    "luminance": round(ltr_data[BreakoutLTR559.LUX], 2),
+    "temperature": temperature,
+    "humidity": humidity,
+    "pressure": pressure,
+    "luminance": luminance,
     "wind_speed": wind_speed(),
     "rain": rain,
     "rain_per_second": rain_per_second,


### PR DESCRIPTION
Moved things around to make each board file follow a more uniform format
Includes shifting import to the top of the file and removing unused imports 
Extends usb power adjustment to all boards (originally only on indoor.py)  - also covered by #160 


