### PR TITLE
Update ENVIRO_VERSION

### DIFF
--- a/enviro/constants.py
+++ b/enviro/constants.py
@@ -1,5 +1,5 @@
 # version
-ENVIRO_VERSION = "0.0.10" 
+ENVIRO_VERSION = "0.2.0"
  
 # modules
 ENVIRO_UNKNOWN                = None


### PR DESCRIPTION
The v0.2.0 release incorrectly logs itself as v0.0.10.

It'll need bumping again if a release to include it happens, but at least it'll be less wrong, including for anyone building their own. :)