### PR TITLE
Retry wifi join on transient negative link status

### DIFF
--- a/enviro/__init__.py
+++ b/enviro/__init__.py
@@ -231,7 +231,8 @@ def reconnect_wifi(ssid, password, country, hostname=None):
   logging.info(f"> Connecting to SSID {ssid} (password: {password})...")
   wlan.connect(ssid, password)
   try:
-    wait_status(CYW43_LINK_UP)
+    if not wait_status(CYW43_LINK_UP):
+      raise Exception(f"timed out in state {wlan.status()} waiting for link up")
   except Exception as x:
     raise Exception(f"Failed to connect to SSID {ssid} (password: {password}): {x}")
   logging.info("> Connected successfully!")

--- a/enviro/__init__.py
+++ b/enviro/__init__.py
@@ -227,14 +227,34 @@ def reconnect_wifi(ssid, password, country, hostname=None):
       raise Exception(f"Failed to disconnect: {x}")
   logging.info("> Ready for connection!")
 
-  # Connect to our AP
+  # Connect to our AP. The CYW43 can report a transient negative status —
+  # LINK_FAIL, or even BADAUTH with a correct password after a cold boot —
+  # when a fresh join attempt made seconds later succeeds. Tear the link
+  # down and retry a few times before giving up, rather than abandoning
+  # the whole cycle on the first bad status.
   logging.info(f"> Connecting to SSID {ssid} (password: {password})...")
-  wlan.connect(ssid, password)
-  try:
-    if not wait_status(CYW43_LINK_UP):
-      raise Exception(f"timed out in state {wlan.status()} waiting for link up")
-  except Exception as x:
-    raise Exception(f"Failed to connect to SSID {ssid} (password: {password}): {x}")
+  last_error = None
+  for attempt in range(3):
+    try:
+      if attempt > 0:
+        logging.info(f"> Retrying connection ({attempt + 1}/3)...")
+        wlan.disconnect()  # cyw43_wifi_leave(): reset the join state machine
+        try:
+          wait_status(CYW43_LINK_DOWN, timeout=5)
+        except Exception:
+          # the failed attempt's negative status can linger briefly;
+          # teardown is best-effort — always proceed to a fresh join
+          pass
+        time.sleep(1)
+      wlan.connect(ssid, password)
+      if wait_status(CYW43_LINK_UP):
+        last_error = None
+        break
+      last_error = f"timed out in state {wlan.status()} waiting for link up"
+    except Exception as x:
+      last_error = str(x)
+  if last_error is not None:
+    raise Exception(f"Failed to connect to SSID {ssid} (password: {password}): {last_error}")
   logging.info("> Connected successfully!")
 
   ip, subnet, gateway, dns = wlan.ifconfig()


### PR DESCRIPTION
# Retry wifi join on transient negative link status

## Problem

`reconnect_wifi()` gives up on the **first** negative status from the CYW43: `wait_status()` raises as soon as `wlan.status()` goes negative, and the caller re-raises without retrying the join. In practice the CYW43 can report a transient failure (typically `CYW43_LINK_FAIL`, ~3 s after `wlan.connect()`) even though a *fresh join attempt made seconds later* succeeds. By then the firmware has already logged a failure, lit the warning LED, and gone back to sleep — so every blip costs a full reading-upload cycle and leaves the WARN LED blinking, which reads to users like a real configuration problem.

## Evidence it's the connect logic, not RF or config

Diagnosed on an Enviro Grow (2.4 GHz, WPA2-only, PMF off, AP under 16% channel utilisation, RSSI −53 at the board's position, AP is a UniFi UDR7):

- The on-device `log.txt` showed association failing on ~50% of 5-minute wakes over one evening, ending in six consecutive failures; each "failure" was logged exactly ~3 s after "connecting" — the first negative status poll.
- After one logged failure, the UniFi controller showed **the same radio associating ~2 minutes later** (signal −46 dBm, satisfaction 100) — the environment was joinable moments after the firmware gave up.
- A manual `wlan.connect()` at the REPL from the same position associated instantly.

## Fix (two commits)

**Commit 1** fixes an independent pre-existing bug: `wait_status(CYW43_LINK_UP)` returning `False` (timeout) was ignored, so a join that associated but never got a DHCP lease fell through to "Connected successfully!" and the caller proceeded with a dead network and no useful error. A timeout now raises, reporting the link state it was stuck in.

**Commit 2** retries the join up to 3 times. Design points, deliberately:

- **Between attempts it disconnects and waits for `LINK_DOWN` first.** MicroPython's `connect()` calls `cyw43_wifi_join()` with no preceding `cyw43_wifi_leave()` ([extmod/network_cyw43.c](https://github.com/micropython/micropython/blob/master/extmod/network_cyw43.c)), and the Pico W SDK guidance is to leave before rejoining after a failure. This also prevents a stale negative status from the previous attempt being misread as a new failure on the next poll.
- **`wlan.connect()` is inside the `try`** so a synchronous `OSError` from a wedged driver counts as a failed attempt rather than crashing the cycle.
- **All negative statuses are retried, including `BADAUTH`.** That is intentional: `-3` is reported with a *correct* password on cold boots (see e.g. [micropython#12930 discussion of first-attempt −1/−3 statuses](https://github.com/micropython/micropython/issues/12930)), and on battery an Enviro cold-boots on every wake. A genuinely wrong password now costs ~30 s extra once per wake — but a wrongly-abandoned retry on a spurious `BADAUTH` would cost the whole cycle.
- **Battery cost is confined to the failure path.** Cycles that connect first try are unchanged; worst case on total network outage is ~35 s awake versus ~10 s before. Under the old behaviour those cycles were lost anyway (reading cached, uploaded on a later successful cycle — which itself costs an extra connection).

3 attempts × 1 s pause is a judgment call, not tuned from a large sample: observed transient failures resolved within seconds (manual rejoin instant; radio associated by itself well within the next wake), so three well-separated fresh joins comfortably covers the observed recovery window while keeping the worst case bounded.

## Testing

A minimal variant of this retry (re-kick `wlan.connect()` on negative status, without the disconnect/teardown — the 0.0.10 code this was diagnosed on has a different loop structure) has been running on the affected Enviro Grow: immediately before, the board had failed six consecutive 5-minute wake cycles; since patching, every wake cycle has connected and uploaded (10 consecutive cycles over the first 50 minutes at time of writing) with the warning LED staying off. The exact code in this PR compiles clean (CPython `compile()` and on-device checks of the equivalent change); I'm happy to run this branch on the board and report back if useful.

For context, similar symptoms (intermittent connect failures / blinking warning LED despite good RF) have been reported in the [Enviro Grow](https://forums.pimoroni.com/t/enviro-grow-wifi-issue/25385) and [Enviro Indoor](https://forums.pimoroni.com/t/enviro-indoor-pico-w-aboard-wifi-connection-always-failing/23502) forum threads — I can't confirm those share this root cause, but the symptom signature matches.
